### PR TITLE
[Feat] 이슈, 레이블, 마일스톤 개수 조회

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.issue;
 
+import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class IssueController {
 
     private final IssueService issueService;
+    private final IssueCountService issueCountService;
 
     @GetMapping("")
     public ResponseEntity<IssueResponseDto.IssueListDto> showIssueList(@RequestParam(name = "is_open") boolean isOpen, Pageable pageable) {
@@ -22,5 +24,11 @@ public class IssueController {
         IssueResponseDto.IssueListDto issues = issueService.getIssues(isOpen, pageable.getPageNumber(), pageable.getPageSize());
 
         return ResponseEntity.ok(issues);
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<IssueCountDto> showIssueCount() {
+        IssueCountDto result = issueCountService.getIssueCounts();
+        return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueCountService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueCountService.java
@@ -1,0 +1,28 @@
+package codesquad.team4.issuetracker.issue;
+
+import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IssueCountService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public IssueCountDto getIssueCounts() {
+        //// 쿼리 결과가 null일 경우 NPE 방지를 위해 int 대신 Integer 사용 -> queryForObject(...)가 null반환 할 수 있음
+        Integer openCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM issue WHERE is_open = true", Integer.class
+        );
+        Integer closedCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM issue WHERE is_open = false", Integer.class
+        );
+
+        return IssueCountDto.builder()
+                .openCount(openCount)
+                .closedCount(closedCount)
+                .build();
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueCountDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueCountDto.java
@@ -1,0 +1,13 @@
+package codesquad.team4.issuetracker.issue.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+@Builder
+public class IssueCountDto {
+    private Integer openCount;
+    private Integer closedCount;
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -1,0 +1,22 @@
+package codesquad.team4.issuetracker.label;
+
+import codesquad.team4.issuetracker.label.dto.LabelCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/labels")
+public class LabelController {
+    private final LabelService labelService;
+
+    @GetMapping("/count")
+    public ResponseEntity<LabelCountDto> getLabelCount() {
+        LabelCountDto result = labelService.getLabelCount();
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -1,0 +1,18 @@
+package codesquad.team4.issuetracker.label;
+
+import codesquad.team4.issuetracker.label.dto.LabelCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LabelService {
+    private final JdbcTemplate jdbcTemplate;
+    public LabelCountDto getLabelCount() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM label", Integer.class);
+
+        return new LabelCountDto(count);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelCountDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelCountDto.java
@@ -1,0 +1,10 @@
+package codesquad.team4.issuetracker.label.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class LabelCountDto {
+    private Integer count;
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
@@ -1,0 +1,22 @@
+package codesquad.team4.issuetracker.milestone;
+
+import codesquad.team4.issuetracker.milestone.dto.MilestoneCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/milestones")
+public class MilestoneController {
+    private final MilestoneService milestoneService;
+
+    @GetMapping("/count")
+    public ResponseEntity<MilestoneCountDto> getMilestoneCount() {
+        MilestoneCountDto result = milestoneService.getMilestoneCount();
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
@@ -1,0 +1,18 @@
+package codesquad.team4.issuetracker.milestone;
+
+import codesquad.team4.issuetracker.milestone.dto.MilestoneCountDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MilestoneService {
+    private final JdbcTemplate jdbcTemplate;
+
+    public MilestoneCountDto getMilestoneCount() {
+        Integer count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM milestone", Integer.class);
+
+        return new MilestoneCountDto(count);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneCountDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneCountDto.java
@@ -1,0 +1,10 @@
+package codesquad.team4.issuetracker.milestone.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MilestoneCountDto {
+    private Integer count;
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueCountServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueCountServiceTest.java
@@ -1,0 +1,38 @@
+package codesquad.team4.issuetracker.issue;
+
+import codesquad.team4.issuetracker.issue.dto.IssueCountDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional //test 후 자동 rollback
+public class IssueCountServiceTest {
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private IssueCountService issueCountService;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate.update("INSERT INTO issue (issue_id, title, is_open, author_id, create_at, updated_at) VALUES (1, open1, true, 1, NOW(), NOW())");
+        jdbcTemplate.update("INSERT INTO issue(issue_id, title, is_open, author_id, create_at, updated_at) VALUES (2, open2, true, 1, NOW(), NOW())");
+        jdbcTemplate.update("INSERT INTO issue(issue_id, title, is_open, author_id, create_at, updated_at) VALUES (3, closed1, false, 1, NOW(), NOW())");
+    }
+
+    @Test
+    @DisplayName("이슈 상태별 개수 반환")
+    void 이슈_상태별_개수_반환() {}
+    IssueCountDTO result = issueCountService.getIssueCounts();
+
+    assertThat(result.getOpenCount()).isEqualTo(2);
+    assertThat(result.getClosedCount()).isEqualTo(1);
+
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueCountServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueCountServiceTest.java
@@ -1,38 +1,43 @@
 package codesquad.team4.issuetracker.issue;
 
-import codesquad.team4.issuetracker.issue.dto.IssueCountDTO;
-import org.junit.jupiter.api.BeforeEach;
+import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
-@AutoConfigureTestDatabase
-@Transactional //test 후 자동 rollback
-public class IssueCountServiceTest {
-    @Autowired
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class IssueCountServiceTest {
+
+    @Mock
     private JdbcTemplate jdbcTemplate;
 
-    @Autowired
+    @InjectMocks
     private IssueCountService issueCountService;
-
-    @BeforeEach
-    void setUp() {
-        jdbcTemplate.update("INSERT INTO issue (issue_id, title, is_open, author_id, create_at, updated_at) VALUES (1, open1, true, 1, NOW(), NOW())");
-        jdbcTemplate.update("INSERT INTO issue(issue_id, title, is_open, author_id, create_at, updated_at) VALUES (2, open2, true, 1, NOW(), NOW())");
-        jdbcTemplate.update("INSERT INTO issue(issue_id, title, is_open, author_id, create_at, updated_at) VALUES (3, closed1, false, 1, NOW(), NOW())");
-    }
 
     @Test
     @DisplayName("이슈 상태별 개수 반환")
-    void 이슈_상태별_개수_반환() {}
-    IssueCountDTO result = issueCountService.getIssueCounts();
+    void 이슈_상태별_개수_반환() {
+        // given
+        given(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM issue WHERE is_open = true", Integer.class)
+        ).willReturn(2);
 
-    assertThat(result.getOpenCount()).isEqualTo(2);
-    assertThat(result.getClosedCount()).isEqualTo(1);
+        given(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM issue WHERE is_open = false", Integer.class)
+        ).willReturn(1);
 
+        // when
+        IssueCountDto result = issueCountService.getIssueCounts();
+
+        // then
+        assertThat(result.getOpenCount()).isEqualTo(2);
+        assertThat(result.getClosedCount()).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/label/LabelServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/label/LabelServiceTest.java
@@ -1,0 +1,34 @@
+package codesquad.team4.issuetracker.label;
+
+import codesquad.team4.issuetracker.label.dto.LabelCountDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class LabelServiceTest {
+
+    @Mock
+    JdbcTemplate jdbcTemplate;
+    @InjectMocks
+    LabelService labelService; //todo 서비스를 테스트하는건데 서비스가 Mock이면 검사가 안됨
+
+    @Test
+    @DisplayName("생성된 레이블 개수 반환")
+    void 레이블_개수_조회() {
+        given(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM label", Integer.class))
+                .willReturn(8);
+
+        LabelCountDto result = labelService.getLabelCount();
+
+        assertThat(result.getCount()).isEqualTo(8);
+    }
+
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/milestone/MilestoneServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/milestone/MilestoneServiceTest.java
@@ -1,0 +1,32 @@
+package codesquad.team4.issuetracker.milestone;
+
+import codesquad.team4.issuetracker.milestone.dto.MilestoneCountDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MilestoneServiceTest {
+    @Mock
+    JdbcTemplate jdbcTemplate;
+    @InjectMocks
+    MilestoneService milestoneService;
+
+    @Test
+    @DisplayName("생성된 마일스톤 개수 반환")
+    void 마일스톤_개수_반환() {
+        given(jdbcTemplate.queryForObject("SELECT COUNT(*) FROM milestone", Integer.class))
+                .willReturn(8);
+
+        MilestoneCountDto result = milestoneService.getMilestoneCount();
+
+        assertThat(result.getCount()).isEqualTo(8);
+    }
+}


### PR DESCRIPTION
🔥 작업 내용 요약

사용자는 open/closed된 이슈의 개수 조회
레이블 개수와 마일스톤 개수를 각각 조회

✅ 작업 상세 내용
* 상태(open/closed)별 이슈 개수 조회 API
* 레이블 개수 조회 API
* 마일스톤 개수 조회 API
* 서비스 단위 테스트 작성

Close #9 