### PR TITLE
[Feat] 이슈 생성 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation platform('software.amazon.awssdk:bom:2.25.3')
+	implementation 'software.amazon.awssdk:s3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/codesquad/team4/issuetracker/aws/S3Config.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/aws/S3Config.java
@@ -1,0 +1,31 @@
+package codesquad.team4.issuetracker.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/aws/S3FileService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/aws/S3FileService.java
@@ -1,0 +1,58 @@
+package codesquad.team4.issuetracker.aws;
+
+import codesquad.team4.issuetracker.exception.FileUploadException;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class S3FileService {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String uploadFile(MultipartFile file, String directory) {
+        return Optional.ofNullable(file)
+                .filter(f -> !f.isEmpty())  // 파일이 비어있지 않은 경우에만 처리
+                .map(f -> {
+                    String originalFilename = f.getOriginalFilename();
+                    String key = directory + UUID.randomUUID() + "_" + originalFilename;
+
+                    // S3에 파일을 업로드하기 위한 요청 객체 생성
+                    PutObjectRequest putObjectRequest = getRequest(f, key);
+
+                    // S3 클라이언트를 통해 파일 업로드
+                    try {
+                        s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(f.getInputStream(), f.getSize()));
+                    } catch (IOException e) {
+                        log.error("파일 업로드 중 오류 발생: {}", e.getMessage(), e);
+                        throw new FileUploadException("파일 업로드에 실패했습니다.", e);
+                    }
+
+                    log.info("S3 업로드 성공");
+                    return String.format("https://%s.s3.amazonaws.com/%s", bucket, key);
+                })
+                .orElse("");  // 파일이 null이거나 비어있으면 빈 문자열 반환
+    }
+
+    private PutObjectRequest getRequest(MultipartFile f, String key) {
+        return PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .acl("public-read") // 퍼블릭 읽기 권한
+                .contentType(f.getContentType())
+                .build();
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Comment.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Comment.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table
 @AllArgsConstructor
 @Getter
+@Builder
 public class Comment {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Issue.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Issue.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("issue")
 @AllArgsConstructor
 @Getter
+@Builder
 public class Issue {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueAssignee.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueAssignee.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("issue_assignee")
 @AllArgsConstructor
 @Getter
+@Builder
 public class IssueAssignee {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueLabel.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueLabel.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("issue_label")
 @AllArgsConstructor
 @Getter
+@Builder
 public class IssueLabel {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Label.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Label.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("label")
 @AllArgsConstructor
 @Getter
+@Builder
 public class Label {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("milestone")
 @AllArgsConstructor
 @Getter
+@Builder
 public class Milestone {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/User.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/User.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.entity;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Table;
@@ -9,6 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("user")
 @AllArgsConstructor
 @Getter
+@Builder
 public class User {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/FileUploadException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/FileUploadException.java
@@ -1,0 +1,11 @@
+package codesquad.team4.issuetracker.exception;
+
+public class FileUploadException extends RuntimeException{
+    public FileUploadException(String message) {
+        super(message);
+    }
+
+    public FileUploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -1,22 +1,33 @@
 package codesquad.team4.issuetracker.issue;
 
+import codesquad.team4.issuetracker.aws.S3FileService;
+import codesquad.team4.issuetracker.exception.FileUploadException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/issues")
 public class IssueController {
+    private static final String ISSUE_DIRECTORY = "issues/";
+    public static final String FILE_UPLOAD_FAILED = "파일 업로드에 실패했습니다.";
 
     private final IssueService issueService;
     private final IssueCountService issueCountService;
+    private final S3FileService s3FileService;
 
     @GetMapping("")
     public ResponseEntity<IssueResponseDto.IssueListDto> showIssueList(@RequestParam(name = "is_open") boolean isOpen, Pageable pageable) {
@@ -29,6 +40,25 @@ public class IssueController {
     @GetMapping("/count")
     public ResponseEntity<IssueCountDto> showIssueCount() {
         IssueCountDto result = issueCountService.getIssueCounts();
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<IssueResponseDto.CreateIssueDto> createIssue(
+            @RequestPart("issue") IssueRequestDto.CreateIssueDto request,
+            @RequestPart(value = "file", required = false) MultipartFile file) throws IOException {
+        String uploadUrl;
+
+        try {
+            uploadUrl = s3FileService.uploadFile(file, ISSUE_DIRECTORY);
+        } catch (FileUploadException e) {
+            return ResponseEntity.badRequest().body(
+                    IssueResponseDto.CreateIssueDto.builder()
+                    .message(FILE_UPLOAD_FAILED)
+                    .build());
+        }
+
+        IssueResponseDto.CreateIssueDto result = issueService.createIssue(request, uploadUrl);
         return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueRepository.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.issue;
+
+import codesquad.team4.issuetracker.entity.Issue;
+import org.springframework.data.repository.CrudRepository;
+
+public interface IssueRepository extends CrudRepository<Issue, Long> {
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class IssueService {
+    private static final String CREATE_ISSUE = "이슈가 생성되었습니다";
 
     private final JdbcTemplate jdbcTemplate;
     private final IssueRepository issueRepository;
@@ -175,7 +176,7 @@ public class IssueService {
 
         return IssueResponseDto.CreateIssueDto.builder()
                 .id(issueId)
-                .message("이슈가 생성되었습니다")
+                .message(CREATE_ISSUE)
                 .build();
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -1,22 +1,36 @@
 package codesquad.team4.issuetracker.issue;
 
+import codesquad.team4.issuetracker.entity.Issue;
+import codesquad.team4.issuetracker.entity.Issue.IssueBuilder;
+import codesquad.team4.issuetracker.entity.IssueAssignee;
+import codesquad.team4.issuetracker.entity.IssueLabel;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.CreateIssueDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.UserInfo;
+import codesquad.team4.issuetracker.label.IssueLabelRepository;
+import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class IssueService {
 
     private final JdbcTemplate jdbcTemplate;
+    private final IssueRepository issueRepository;
+    private final IssueLabelRepository issueLabelRepository;
+    private final IssueAssigneeRepository issueAssigneeRepository;
 
     public IssueResponseDto.IssueListDto getIssues(boolean isOpen, int page, int size) {
         int offset = Math.max(0, (page - 1) * size);
@@ -115,6 +129,53 @@ public class IssueService {
                 .size(size)
                 .totalElements(totalElements)
                 .totalPages(totalPages)
+                .build();
+    }
+
+    @Transactional
+    public CreateIssueDto createIssue(IssueRequestDto.CreateIssueDto request, String uploadUrl) {
+        IssueBuilder issueBuilder = Issue.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .imageUrl(uploadUrl)
+                .isOpen(true)
+                .authorId(request.getAuthorId())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now());
+
+        Optional.ofNullable(request.getMilestoneId())
+                .ifPresent(issueBuilder::milestoneId);
+
+        Issue issue = issueBuilder.build();
+        Issue savedIssue = issueRepository.save(issue);
+
+        Long issueId = savedIssue.getId();
+
+        for (Long labelId : Optional.ofNullable(request.getLabelId()).orElse(List.of())) {
+            IssueLabel issueLabel = IssueLabel.builder()
+                    .issueId(issueId)
+                    .labelId(labelId)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            issueLabelRepository.save(issueLabel);
+        }
+
+        for (Long assigneeId : Optional.ofNullable(request.getAssigneeId()).orElse(List.of())) {
+            IssueAssignee issueAssignee = IssueAssignee.builder()
+                    .issueId(issueId)
+                    .assigneeId(assigneeId)
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+
+            issueAssigneeRepository.save(issueAssignee);
+        }
+
+        return IssueResponseDto.CreateIssueDto.builder()
+                .id(issueId)
+                .message("이슈가 생성되었습니다")
                 .build();
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.issue.dto;
 
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,8 +10,12 @@ public class IssueRequestDto {
     @AllArgsConstructor
     @Getter
     @Builder
-    public static class CreateIssueDto {
-        private Long id;
-        private String messqge;
+    public static class CreateIssueDto{
+        private String title;
+        private String content;
+        private Long authorId;
+        private List<Long> assigneeId;
+        private List<Long> labelId;
+        private Long milestoneId;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -1,0 +1,16 @@
+package codesquad.team4.issuetracker.issue.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class IssueRequestDto {
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class CreateIssueDto {
+        private Long id;
+        private String messqge;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -52,6 +52,6 @@ public class IssueResponseDto {
     @Builder
     public static class CreateIssueDto {
         private Long id;
-        private String messqge;
+        private String message;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -46,4 +46,16 @@ public class IssueResponseDto {
         private Long id;
         private String name;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class CreateIssueDto{
+        private String title;
+        private String content;
+        private Long authorId;
+        private List<Long> assigneeId;
+        private List<Long> labelId;
+        private Long milestoneId;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -50,12 +50,8 @@ public class IssueResponseDto {
     @AllArgsConstructor
     @Getter
     @Builder
-    public static class CreateIssueDto{
-        private String title;
-        private String content;
-        private Long authorId;
-        private List<Long> assigneeId;
-        private List<Long> labelId;
-        private Long milestoneId;
+    public static class CreateIssueDto {
+        private Long id;
+        private String messqge;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/IssueLabelRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/IssueLabelRepository.java
@@ -1,0 +1,8 @@
+package codesquad.team4.issuetracker.label;
+
+import codesquad.team4.issuetracker.entity.Issue;
+import codesquad.team4.issuetracker.entity.IssueLabel;
+import org.springframework.data.repository.CrudRepository;
+
+public interface IssueLabelRepository extends CrudRepository<IssueLabel, Long> {
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/user/IssueAssigneeRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/user/IssueAssigneeRepository.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.user;
+
+import codesquad.team4.issuetracker.entity.IssueAssignee;
+import org.springframework.data.repository.CrudRepository;
+
+public interface IssueAssigneeRepository extends CrudRepository<IssueAssignee, Long> {
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -14,3 +14,19 @@ spring:
     init:
       mode: never
       schema-locations: classpath:schema.sql
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2  # 버킷의 리전
+    s3:
+      bucket: bbz-issuetracker-bucket   # 버킷 이름
+    stack:
+      auto: false
+
+logging:
+  level:
+    root: INFO

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE issue (
                        image_url VARCHAR(255),
                        author_id BIGINT NOT NULL,
                        milestone_id BIGINT,
+                       comment_id BIGINT,
                        is_open BOOLEAN DEFAULT true,
                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -1,0 +1,102 @@
+package codesquad.team4.issuetracker.issue;
+
+import codesquad.team4.issuetracker.aws.S3FileService;
+import codesquad.team4.issuetracker.exception.FileUploadException;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(IssueController.class)
+class IssueControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IssueService issueService;
+    @MockitoBean
+    private IssueCountService issueCountService;
+    @MockitoBean
+    private S3FileService s3FileService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("파일과 이슈 데이터로 이슈를 생성할 수 있다")
+    void createIssue_success() throws Exception {
+        // given
+        IssueRequestDto.CreateIssueDto requestDto = IssueRequestDto.CreateIssueDto.builder()
+                .title("이슈 제목")
+                .content("이슈 설명")
+                .authorId(1L)
+                .build();
+
+        String jsonPart = objectMapper.writeValueAsString(requestDto);
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "issue", "", "application/json", jsonPart.getBytes());
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "image.png", "image/png", "image-content".getBytes());
+
+        given(s3FileService.uploadFile(any(), eq("issue/"))).willReturn("https://fake-s3-url/image.png");
+
+        IssueResponseDto.CreateIssueDto responseDto = IssueResponseDto.CreateIssueDto.builder()
+                .id(1L)
+                .message("이슈가 생성되었습니다.")
+                .build();
+
+        given(issueService.createIssue(any(), any())).willReturn(responseDto);
+
+        // when & then
+        mockMvc.perform(multipart("/api/issues")
+                        .file(jsonFile)
+                        .file(file)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.message").value("이슈가 생성되었습니다."));
+    }
+
+    @Test
+    @DisplayName("파일 업로드 실패시 BadRequest를 반환한다")
+    void createIssue_fileUploadFail() throws Exception {
+        IssueRequestDto.CreateIssueDto requestDto = IssueRequestDto.CreateIssueDto.builder()
+                .title("이슈 제목")
+                .content("이슈 설명")
+                .authorId(1L)
+                .build();
+
+        String jsonPart = objectMapper.writeValueAsString(requestDto);
+
+        MockMultipartFile jsonFile = new MockMultipartFile(
+                "issue", "", "application/json", jsonPart.getBytes());
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "image.png", "image/png", "image-content".getBytes());
+
+        given(s3FileService.uploadFile(any(), eq("issues/"))).willThrow(new FileUploadException("파일 업로드에 실패했습니다."));
+
+        mockMvc.perform(multipart("/api/issues")
+                        .file(jsonFile)
+                        .file(file)
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("파일 업로드에 실패했습니다."));
+    }
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -1,10 +1,9 @@
 package codesquad.team4.issuetracker.issue;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.hamcrest.Matchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
@@ -15,7 +14,6 @@ import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +22,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.jdbc.core.JdbcTemplate;
 
 @ExtendWith(MockitoExtension.class)
 public class IssueServiceTest {
@@ -72,7 +69,7 @@ public class IssueServiceTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        when(issueRepository.save(Mockito.any(Issue.class))).thenReturn(issue);
+        given(issueRepository.save(Mockito.any(Issue.class))).willReturn(issue);
 
         // when
         CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
@@ -108,7 +105,7 @@ public class IssueServiceTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        when(issueRepository.save(Mockito.any(Issue.class))).thenReturn(issue);
+        given(issueRepository.save(Mockito.any(Issue.class))).willReturn(issue);
 
         // when
         CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -1,11 +1,125 @@
 package codesquad.team4.issuetracker.issue;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.hamcrest.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import codesquad.team4.issuetracker.entity.Issue;
+import codesquad.team4.issuetracker.entity.IssueAssignee;
+import codesquad.team4.issuetracker.entity.IssueLabel;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.CreateIssueDto;
+import codesquad.team4.issuetracker.label.IssueLabelRepository;
+import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 public class IssueServiceTest {
 
+    @Mock
+    private IssueRepository issueRepository;
 
+    @Mock
+    private IssueLabelRepository issueLabelRepository;
+
+    @Mock
+    private IssueAssigneeRepository issueAssigneeRepository;
+
+    @InjectMocks
+    private IssueService issueService;
+
+    private IssueRequestDto.CreateIssueDto.CreateIssueDtoBuilder requestDtoBuilder;
+
+    @BeforeEach
+    public void setup() {
+        requestDtoBuilder = IssueRequestDto.CreateIssueDto.builder()
+                .title("Test Issue")
+                .content("Test Content")
+                .authorId(1L)
+                .milestoneId(null)
+                .labelId(List.of(1L, 2L))
+                .assigneeId(List.of(1L, 2L));
+    }
+
+    @Test
+    @DisplayName("새 이슈를 생성할 때, 정상적으로 이슈와 관련된 레이블과 담당자가 저장되어야 한다")
+    public void testCreateIssue_Success() {
+        // given
+        IssueRequestDto.CreateIssueDto requestDto = requestDtoBuilder.build();
+        String uploadUrl = "http://example.com/uploaded_image.jpg";
+
+        Issue issue = Issue.builder()
+                .id(1L)
+                .title("Test Issue")
+                .content("Test Content")
+                .imageUrl(uploadUrl)
+                .isOpen(true)
+                .authorId(1L)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(issueRepository.save(Mockito.any(Issue.class))).thenReturn(issue);
+
+        // when
+        CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getMessage()).isEqualTo("이슈가 생성되었습니다");
+
+        verify(issueRepository, times(1)).save(Mockito.any(Issue.class));
+        verify(issueLabelRepository, times(2)).save(Mockito.any(IssueLabel.class));
+        verify(issueAssigneeRepository, times(2)).save(Mockito.any(IssueAssignee.class));
+    }
+
+    @Test
+    @DisplayName("새 이슈를 생성할 때, 레이블과 담당자가 없어도 저장되어야 한다")
+    public void testCreateIssue_NoLabelsAndAssignees() {
+        // given
+        IssueRequestDto.CreateIssueDto requestDto = requestDtoBuilder
+                .labelId(null)
+                .assigneeId(null)
+                .build();
+        String uploadUrl = "http://example.com/uploaded_image.jpg";
+
+        Issue issue = Issue.builder()
+                .id(1L)
+                .title("Test Issue")
+                .content("Test Content")
+                .imageUrl(uploadUrl)
+                .isOpen(true)
+                .authorId(1L)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        when(issueRepository.save(Mockito.any(Issue.class))).thenReturn(issue);
+
+        // when
+        CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getId()).isEqualTo(1L);
+        assertThat(response.getMessage()).isEqualTo("이슈가 생성되었습니다");
+
+        verify(issueRepository, times(1)).save(Mockito.any(Issue.class));
+        verify(issueLabelRepository, times(0)).save(Mockito.any(IssueLabel.class)); // No labels
+        verify(issueAssigneeRepository, times(0)).save(Mockito.any(IssueAssignee.class)); // No assignees
+    }
 }


### PR DESCRIPTION
🔥 작업 내용 요약

- 이슈 작성 버튼을 누른경우 입력 내용을 DB에 저장
- 파일을 S3에 저장

✅ 작업 상세 내용

- 이슈의 제목, 내용, 담당자, 레이블, 마일스톤을 포함하는 이슈를 생성
- 담당자, 레이블, 마일스톤이 선택되지 않은 경우도 이슈가 생성
- 파일 저장을 위한 S3를 설정
- S3에 저장된 이미지 url을 DB에 저장
- 컨트롤러, 서비스단 단위테스트를 작성

🚧 고려사항

- 서비스 내부의 빌더 코드들을 외부의 클래스로 분리할지 서비스 내부의 메소드로 분리할지 결정 필요
- 컨트롤러단의 에러를 처리하기 위한 ControllerAdvice를 설정할지 고민

Close #13 