### PR TITLE
[FEAT] 이슈 일괄 상태 변경

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/aws/S3FileService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/aws/S3FileService.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.aws;
 
-import static codesquad.team4.issuetracker.issue.IssueController.FILE_UPLOAD_FAILED;
+import codesquad.team4.issuetracker.exception.ExceptionMessage;
 
 import codesquad.team4.issuetracker.exception.FileUploadException;
 import java.io.IOException;
@@ -44,7 +44,7 @@ public class S3FileService {
                         s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(f.getInputStream(), f.getSize()));
                     } catch (IOException e) {
                         log.error("파일 업로드 중 오류 발생: {}", e.getMessage(), e);
-                        throw new FileUploadException(FILE_UPLOAD_FAILED, e);
+                        throw new FileUploadException(ExceptionMessage.FILE_UPLOAD_FAILED, e);
                     }
 
                     log.info("S3 업로드 성공");

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -1,0 +1,8 @@
+package codesquad.team4.issuetracker.exception;
+
+public class ExceptionMessage {
+    public static final String NO_ISSUE_IDS = "변경할 이슈 ID가 없습니다.";
+    public static final String ISSUE_IDS_NOT_FOUND ="요청한 이슈 ID가 존재하지 않습니다.";
+    public static final String FILE_UPLOAD_FAILED = "파일 업로드에 실패했습니다.";
+    public static final String UPDATE_ISSUE_FAILED =  "이슈가 존재하지 않습니다";
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueStatusUpdateException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueStatusUpdateException.java
@@ -1,0 +1,8 @@
+package codesquad.team4.issuetracker.exception;
+
+
+public class IssueStatusUpdateException extends RuntimeException {
+    public IssueStatusUpdateException(String message) {
+        super (message);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -2,20 +2,18 @@ package codesquad.team4.issuetracker.issue;
 
 import codesquad.team4.issuetracker.aws.S3FileService;
 import codesquad.team4.issuetracker.exception.FileUploadException;
+import codesquad.team4.issuetracker.exception.ExceptionMessage;
+import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import java.io.IOException;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -23,7 +21,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/api/issues")
 public class IssueController {
     private static final String ISSUE_DIRECTORY = "issues/";
-    public static final String FILE_UPLOAD_FAILED = "파일 업로드에 실패했습니다.";
 
     private final IssueService issueService;
     private final IssueCountService issueCountService;
@@ -54,11 +51,27 @@ public class IssueController {
         } catch (FileUploadException e) {
             return ResponseEntity.badRequest().body(
                     IssueResponseDto.CreateIssueDto.builder()
-                    .message(FILE_UPLOAD_FAILED)
+                    .message(ExceptionMessage.FILE_UPLOAD_FAILED)
                     .build());
         }
 
         IssueResponseDto.CreateIssueDto result = issueService.createIssue(request, uploadUrl);
         return ResponseEntity.ok(result);
+    }
+
+    @PatchMapping("/status")
+    public ResponseEntity<IssueResponseDto.BulkUpdateIssueStatusDto> updateIssueStatus(
+            @RequestBody IssueRequestDto.BulkUpdateIssueStatusDto requestDto) {
+        try {
+            IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
+            return ResponseEntity.ok(result);
+        } catch (IssueStatusUpdateException e) {
+            return ResponseEntity.badRequest().body(
+                    IssueResponseDto.BulkUpdateIssueStatusDto.builder()
+                            .message(ExceptionMessage.UPDATE_ISSUE_FAILED)
+                            .build()
+            );
+
+        }
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -18,4 +18,12 @@ public class IssueRequestDto {
         private List<Long> labelId;
         private Long milestoneId;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class BulkUpdateIssueStatusDto {
+        private List<Long> issuesId;
+        private boolean isOpen;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -41,4 +41,12 @@ public class IssueResponseDto {
         private Long id;
         private String message;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class BulkUpdateIssueStatusDto {
+        private List<Long> issuesId;
+        private String message;
+    }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -1,6 +1,8 @@
 package codesquad.team4.issuetracker.issue;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -8,7 +10,9 @@ import static org.mockito.Mockito.verify;
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
 import codesquad.team4.issuetracker.entity.IssueLabel;
+import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.CreateIssueDto;
 import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
@@ -22,6 +26,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @ExtendWith(MockitoExtension.class)
 public class IssueServiceTest {
@@ -34,6 +39,9 @@ public class IssueServiceTest {
 
     @Mock
     private IssueAssigneeRepository issueAssigneeRepository;
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
 
     @InjectMocks
     private IssueService issueService;
@@ -69,7 +77,7 @@ public class IssueServiceTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        given(issueRepository.save(Mockito.any(Issue.class))).willReturn(issue);
+        given(issueRepository.save(any(Issue.class))).willReturn(issue);
 
         // when
         CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
@@ -79,9 +87,9 @@ public class IssueServiceTest {
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getMessage()).isEqualTo("이슈가 생성되었습니다");
 
-        verify(issueRepository, times(1)).save(Mockito.any(Issue.class));
-        verify(issueLabelRepository, times(2)).save(Mockito.any(IssueLabel.class));
-        verify(issueAssigneeRepository, times(2)).save(Mockito.any(IssueAssignee.class));
+        verify(issueRepository, times(1)).save(any(Issue.class));
+        verify(issueLabelRepository, times(2)).save(any(IssueLabel.class));
+        verify(issueAssigneeRepository, times(2)).save(any(IssueAssignee.class));
     }
 
     @Test
@@ -105,7 +113,7 @@ public class IssueServiceTest {
                 .updatedAt(LocalDateTime.now())
                 .build();
 
-        given(issueRepository.save(Mockito.any(Issue.class))).willReturn(issue);
+        given(issueRepository.save(any(Issue.class))).willReturn(issue);
 
         // when
         CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
@@ -115,8 +123,69 @@ public class IssueServiceTest {
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getMessage()).isEqualTo("이슈가 생성되었습니다");
 
-        verify(issueRepository, times(1)).save(Mockito.any(Issue.class));
-        verify(issueLabelRepository, times(0)).save(Mockito.any(IssueLabel.class)); // No labels
-        verify(issueAssigneeRepository, times(0)).save(Mockito.any(IssueAssignee.class)); // No assignees
+        verify(issueRepository, times(1)).save(any(Issue.class));
+        verify(issueLabelRepository, times(0)).save(any(IssueLabel.class)); // No labels
+        verify(issueAssigneeRepository, times(0)).save(any(IssueAssignee.class)); // No assignees
     }
+
+    @Test
+    @DisplayName("상태 변경 성공: 모든 이슈 ID가 유효하면 상태가 정상적으로 변경된다")
+    public void testUpdateIssueStatus_Success() {
+        // given
+        List<Long> issuesId = List.of(1L, 2L, 3L);
+        boolean isOpen = true;
+
+        IssueRequestDto.BulkUpdateIssueStatusDto requestDto = IssueRequestDto.BulkUpdateIssueStatusDto.builder()
+                .issuesId(issuesId)
+                .isOpen(isOpen)
+                .build();
+
+        String placeholders = "?, ?, ?";
+        String countSql = "SELECT COUNT(*) FROM issue WHERE issue_id IN (" + placeholders + ")";
+        String updateSql = "UPDATE issue SET is_open = ? WHERE issue_id IN (" + placeholders + ")";
+
+        Object[] queryArgs = new Object[]{1L, 2L, 3L};
+        Object[] updateArgs = new Object[]{isOpen, 1L, 2L, 3L};
+
+        given(jdbcTemplate.queryForObject(eq(countSql), eq(Integer.class), eq(queryArgs)))
+                .willReturn(3);
+        given(jdbcTemplate.update(eq(updateSql), eq(updateArgs)))
+                .willReturn(3);
+
+        // when
+        IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getIssuesId()).isEqualTo(issuesId);
+        assertThat(result.getMessage()).isEqualTo("이슈 상태가 변경되었습니다.");
+    }
+
+    @Test
+    @DisplayName("상태 변경 실패: 일부 이슈 ID만 존재하면 예외가 발생한다")
+    public void testUpdateIssueStatus_InvalidIds_ThrowsException() {
+        // given
+        List<Long> issuesId = List.of(1L, 2L, 3L);
+        boolean isOpen = false;
+
+        IssueRequestDto.BulkUpdateIssueStatusDto requestDto = IssueRequestDto.BulkUpdateIssueStatusDto.builder()
+                .issuesId(issuesId)
+                .isOpen(isOpen)
+                .build();
+
+        String placeholders = "?, ?, ?";
+        String countSql = "SELECT COUNT(*) FROM issue WHERE issue_id IN (" + placeholders + ")";
+        Object[] queryArgs = new Object[]{1L, 2L, 3L};
+
+        // 일부 ID만 존재한다고 가정 (ex. 2개)
+        given(jdbcTemplate.queryForObject(eq(countSql), eq(Integer.class), eq(queryArgs)))
+                .willReturn(2);
+
+        // when & then
+        assertThatThrownBy(() -> issueService.bulkUpdateIssueStatus(requestDto))
+                .isInstanceOf(IssueStatusUpdateException.class)
+                .hasMessageContaining("일부");
+    }
+
+
 }


### PR DESCRIPTION
🔥 작업 내용 요약
여러 개의 이슈에 대해 한 번에 상태(open/closed)를 변경

클라이언트로 부터 변경할 issues_id, 상태(is_open)를 받으면, 요청받은 이슈들의 상태를 일괄 업데이트

✅ 작업 상세 내용
* 이슈 상태 일괄 변경 API 구현 (PATCH /api/issues/status)
* 요청 바디: issues_id(List), is_open(boolean) 파싱
* 응답 메시지 구성: 안내 메시지
* 서비스 로직에서 트랜잭션 처리 적용
* 이슈 ID가 존재하지 않거나, 일부만 존재할 경우 예외 처리
* 단위 테스트 작성
