### PR TITLE
[CHORE] CORS 설정 추가

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
@@ -1,0 +1,19 @@
+package codesquad.team4.issuetracker.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://3.35.149.171"
+                )
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
🔥 작업 내용 요약
* CORS 설정

✅ 작업 상세 내용
- CORS 정책을 설정하기 위한 WebConfig 클래스 생성
- 프론트엔드 요청 허용 (localhost:3000, 3.35.149.171)
- 모든 메서드 허용 (GET, POST, PUT, DELETE, OPTIONS)
- Credentials 허용