### PR TITLE
[Feat] 이슈 상세조회 API 구현

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/dto/CommentResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/dto/CommentResponseDto.java
@@ -10,7 +10,7 @@ public class CommentResponseDto {
     @AllArgsConstructor
     @Getter
     @Builder
-    public static class commentInfo {
+    public static class CommentInfo {
         private Long commentId;
         private String content;
         private UserDto.UserInfo author;

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/dto/CommentResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/dto/CommentResponseDto.java
@@ -1,0 +1,20 @@
+package codesquad.team4.issuetracker.comment.dto;
+
+import codesquad.team4.issuetracker.user.dto.UserDto;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CommentResponseDto {
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class commentInfo {
+        private Long commentId;
+        private String content;
+        private UserDto.UserInfo author;
+        private String imageUrl;
+        private LocalDateTime createdAt;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -5,4 +5,5 @@ public class ExceptionMessage {
     public static final String ISSUE_IDS_NOT_FOUND ="요청한 이슈 ID가 존재하지 않습니다.";
     public static final String FILE_UPLOAD_FAILED = "파일 업로드에 실패했습니다.";
     public static final String UPDATE_ISSUE_FAILED =  "이슈가 존재하지 않습니다";
+    public static final String NOT_FOUND_ISSUE = "이슈를 찾을 수 없습니다. issueId = ";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package codesquad.team4.issuetracker.exception;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_ISSUE;
+
+import codesquad.team4.issuetracker.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IssueNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleIssueNotFoundException(IssueNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail(NOT_FOUND_ISSUE + ex.getIssueId()));
+    }
+
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueNotFoundException.java
@@ -1,0 +1,11 @@
+package codesquad.team4.issuetracker.exception;
+
+public class IssueNotFoundException extends RuntimeException {
+    public IssueNotFoundException(String message) {
+        super(message);
+    }
+
+    public IssueNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueNotFoundException.java
@@ -1,11 +1,14 @@
 package codesquad.team4.issuetracker.exception;
 
 public class IssueNotFoundException extends RuntimeException {
-    public IssueNotFoundException(String message) {
-        super(message);
+    private final Long issueId;
+
+    public IssueNotFoundException(Long issueId) {
+        super("이슈를 찾을 수 없습니다. issueId = " + issueId);
+        this.issueId = issueId;
     }
 
-    public IssueNotFoundException(String message, Throwable cause) {
-        super(message, cause);
+    public Long getIssueId() {
+        return issueId;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -83,12 +83,12 @@ public class IssueController {
     @GetMapping("/{issue-id}")
     public ResponseEntity<ApiResponse<IssueResponseDto.searchIssueDetailDto>> searchIssueDetail(@PathVariable("issue-id") Long issueId){
         try {
-            IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetialById(issueId);
+            IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetailById(issueId);
             return ResponseEntity.ok(ApiResponse.success(result));
         }catch (IssueNotFoundException e){
             log.error("이슈 조회 실패, issueId : {}", issueId);
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    ApiResponse.fail("해당 이슈를 찾을 수 없습니다."));
+                    ApiResponse.fail("이슈를 찾을 수 없습니다. issueId = " + issueId));
         }
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -3,21 +3,25 @@ package codesquad.team4.issuetracker.issue;
 import codesquad.team4.issuetracker.aws.S3FileService;
 import codesquad.team4.issuetracker.exception.FileUploadException;
 import codesquad.team4.issuetracker.exception.ExceptionMessage;
+import codesquad.team4.issuetracker.exception.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.response.ApiResponse;
 import jakarta.validation.Valid;
-import java.io.IOException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/api/issues")
 public class IssueController {
@@ -73,6 +77,18 @@ public class IssueController {
                             .build()
             );
 
+        }
+    }
+
+    @GetMapping("/{issue-id}")
+    public ResponseEntity<ApiResponse<IssueResponseDto.searchIssueDetailDto>> searchIssueDetail(@PathVariable("issue-id") Long issueId){
+        try {
+            IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetialById(issueId);
+            return ResponseEntity.ok(ApiResponse.success(result));
+        }catch (IssueNotFoundException e){
+            log.error("이슈 조회 실패, issueId : {}", issueId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
+                    ApiResponse.fail("해당 이슈를 찾을 수 없습니다."));
         }
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -82,13 +82,8 @@ public class IssueController {
 
     @GetMapping("/{issue-id}")
     public ResponseEntity<ApiResponse<IssueResponseDto.searchIssueDetailDto>> searchIssueDetail(@PathVariable("issue-id") Long issueId){
-        try {
-            IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetailById(issueId);
-            return ResponseEntity.ok(ApiResponse.success(result));
-        }catch (IssueNotFoundException e){
-            log.error("이슈 조회 실패, issueId : {}", issueId);
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(
-                    ApiResponse.fail("이슈를 찾을 수 없습니다. issueId = " + issueId));
-        }
+        IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetailById(issueId);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -68,8 +68,8 @@
             String sql = """
                 SELECT
                     i.content AS issue_content,
-                    i.imageUrl AS issue_image_url
-                    c.id AS comment_id,
+                    i.image_url AS issue_image_url,
+                    c.comment_id AS comment_id,
                     c.content AS comment_content,
                     c.image_url AS comment_image_url,
                     c.created_at AS comment_created_at,
@@ -77,9 +77,9 @@
                     u.nickname AS author_nickname,
                     u.profile_image AS author_profile
                 FROM issue i
-                JOIN comment c ON i.id = c.issue_id
-                JOIN user u ON u.id = c.author_id
-                where i.id = ?
+                JOIN comment c ON i.issue_id = c.issue_id
+                JOIN user u ON u.user_id = c.author_id
+                where i.issue_id = ?
             """;
 
             return jdbcTemplate.queryForList(sql, issueId);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -2,7 +2,6 @@
 
     import java.util.List;
     import java.util.Map;
-    import java.util.stream.Collectors;
     import lombok.RequiredArgsConstructor;
     import org.springframework.jdbc.core.JdbcTemplate;
     import org.springframework.stereotype.Repository;
@@ -64,4 +63,26 @@
 
             return jdbcTemplate.update(updateSql, params.toArray());
         }
+
+        public List<Map<String, Object>> findIssueDetailById(Long issueId) {
+            String sql = """
+                SELECT
+                    i.content AS issue_content,
+                    i.imageUrl AS issue_image_url
+                    c.id AS comment_id,
+                    c.content AS comment_content,
+                    c.image_url AS comment_image_url,
+                    c.created_at AS comment_created_at,
+                    u.user_id AS author_id,
+                    u.nickname AS author_nickname,
+                    u.profile_image AS author_profile
+                FROM issue i
+                JOIN comment c ON i.id = c.issue_id
+                JOIN user u ON u.id = c.author_id
+                where i.id = ?
+            """;
+
+            return jdbcTemplate.queryForList(sql, issueId);
+        }
+
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -213,7 +213,7 @@ public class IssueService {
     public searchIssueDetailDto getIssueDetailById(Long issueId) {
         List<Map<String, Object>> issueById = issueDao.findIssueDetailById(issueId);
         if (issueById.isEmpty()) {
-            throw new IssueNotFoundException("이슈를 찾을 수 없습니다. issueId = " + issueId);
+            throw new IssueNotFoundException(issueId);
         }
 
         String issueContent = (String) issueById.get(0).get("issue_content");

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.issue.dto;
 
+import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import java.util.List;
@@ -51,5 +52,14 @@ public class IssueResponseDto {
     public static class BulkUpdateIssueStatusDto {
         private List<Long> issuesId;
         private String message;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class searchIssueDetailDto {
+        private String content;
+        private List<CommentResponseDto.commentInfo> comments;
+        private Integer commentSize;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -5,7 +5,6 @@ import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import java.util.List;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import java.util.Set;
 import lombok.AllArgsConstructor;
@@ -59,7 +58,8 @@ public class IssueResponseDto {
     @Builder
     public static class searchIssueDetailDto {
         private String content;
-        private List<CommentResponseDto.commentInfo> comments;
+        private String contentImageUrl;
+        private List<CommentResponseDto.CommentInfo> comments;
         private Integer commentSize;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/response/ApiResponse.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/response/ApiResponse.java
@@ -1,0 +1,46 @@
+package codesquad.team4.issuetracker.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private boolean success;
+
+    private T data;
+
+    private String message;
+
+    // 성공 응답 생성
+    public static <T> ApiResponse<T> success(T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .message(null)
+                .build();
+    }
+
+    // 성공 응답 + 메시지
+    public static <T> ApiResponse<T> success(T data, String message) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .data(data)
+                .message(message)
+                .build();
+    }
+
+    // 실패 응답
+    public static <T> ApiResponse<T> fail(String message) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .data(null)
+                .message(message)
+                .build();
+    }
+}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -51,6 +51,7 @@ CREATE TABLE comment (
                          content TEXT NOT NULL,
                          author_id BIGINT NOT NULL,
                          issue_id BIGINT NOT NULL,
+                         image_url VARCHAR(255),
                          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                          updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -160,7 +160,7 @@ class IssueControllerTest {
         Long notExistIssueId = 999L;
 
         given(issueService.getIssueDetailById(notExistIssueId))
-                .willThrow(new IssueNotFoundException("해당 이슈를 찾을 수 없습니다."));
+                .willThrow(new IssueNotFoundException(notExistIssueId));
 
         // when & then
         mockMvc.perform(get("/api/issues/{issue-id}", notExistIssueId))

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -159,13 +159,13 @@ class IssueControllerTest {
         // given
         Long notExistIssueId = 999L;
 
-        given(issueService.getIssueDetialById(notExistIssueId))
+        given(issueService.getIssueDetailById(notExistIssueId))
                 .willThrow(new IssueNotFoundException("해당 이슈를 찾을 수 없습니다."));
 
         // when & then
         mockMvc.perform(get("/api/issues/{issue-id}", notExistIssueId))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("해당 이슈를 찾을 수 없습니다."));
+                .andExpect(jsonPath("$.message").value("이슈를 찾을 수 없습니다. issueId = " + notExistIssueId));
     }
 
     @Test

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.issue;
 
 import codesquad.team4.issuetracker.aws.S3FileService;
 import codesquad.team4.issuetracker.exception.FileUploadException;
+import codesquad.team4.issuetracker.exception.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
@@ -21,6 +22,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -151,5 +153,23 @@ class IssueControllerTest {
                 .andExpect(jsonPath("$.message").value("이슈가 존재하지 않습니다"));
     }
 
+    @Test
+    @DisplayName("존재하지 않는 이슈를 조회할 경우 에러가 발생한다")
+    void searchNotPresentIssue() throws Exception {
+        // given
+        Long notExistIssueId = 999L;
 
+        given(issueService.getIssueDetialById(notExistIssueId))
+                .willThrow(new IssueNotFoundException("해당 이슈를 찾을 수 없습니다."));
+
+        // when & then
+        mockMvc.perform(get("/api/issues/{issue-id}", notExistIssueId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("해당 이슈를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("이슈를 조회할 때 이슈 내용과 댓글을 함께 응답한다")
+    void searchIssueDetail() {
+    }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -224,7 +224,7 @@ public class IssueServiceTest {
     void getIssueDetailByNotExistId() {
         // given
         Long issueId = 999L;
-        given(issueDao.findIssueById(issueId)).willReturn(Collections.emptyList());
+        given(issueDao.findIssueDetailById(issueId)).willReturn(Collections.emptyList());
 
         // when & then
         assertThatThrownBy(() -> issueService.getIssueDetailById(issueId))

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -203,7 +203,7 @@ public class IssueServiceTest {
         row.put("author_profile", "https://example.com/profile.png");
 
         List<Map<String, Object>> mockResult = List.of(row);
-        given(issueDao.findIssueById(issueId)).willReturn(mockResult);
+        given(issueDao.findIssueDetailById(issueId)).willReturn(mockResult);
 
         // when
         IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetailById(issueId);


### PR DESCRIPTION
🔥 작업 내용 요약
	•	이슈 상세 조회 기능 구현
	•	관련 서비스, 컨트롤러, DTO 작성 및 테스트 코드 작성
	•	ControllerAdvice를 이용한 에러 핸들링

✅ 작업 상세 내용
	•	IssueService.getIssueDetailById() 메서드 구현
	•	/issues/{id} 경로로 이슈 상세 정보를 조회하는 컨트롤러 추가
	•	존재하지 않는 이슈를 조회할 경우 예외를 처리하는 테스트 코드 작성
	•	전체 이슈 상세 정보를 반환하는 DTO 구성: 이슈 내용, 이미지, 댓글 리스트, 댓글 작성자 정보 포함