### PR TITLE
[Feat] 이슈 수정 API 구현

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+backend/.idea/

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Comment.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Comment.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table
@@ -13,11 +14,24 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder
 public class Comment {
     @Id
+    @Column("comment_id")
     private Long id;
+
+    @Column("content")
     private String content;
+
+    @Column("image_url")
     private String imageUrl;
+
+    @Column("issue_id")
     private Long issueId;
+
+    @Column("author_id")
     private Long authorId;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
+
+    @Column("updated_at")
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Issue.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Issue.java
@@ -10,7 +10,7 @@ import org.springframework.data.relational.core.mapping.Table;
 @Table("issue")
 @AllArgsConstructor
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class Issue {
     @Id
     private Long id;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Issue.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Issue.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("issue")
@@ -13,14 +14,31 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder(toBuilder = true)
 public class Issue {
     @Id
+    @Column("issue_id")
     private Long id;
+
+    @Column("title")
     private String title;
+
+    @Column("content")
     private String content;
+
+    @Column("image_url")
     private String imageUrl;
+
+    @Column("is_open")
     private boolean isOpen;
+
+    @Column("author_id")
     private Long authorId;
+
+    @Column("milestone_id")
     private Long milestoneId;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
+
+    @Column("updated_at")
     private LocalDateTime updatedAt;
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueAssignee.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueAssignee.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("issue_assignee")
@@ -13,8 +14,15 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder
 public class IssueAssignee {
     @Id
+    @Column("issue_assignee_id")
     private Long id;
+
+    @Column("issue_id")
     private Long issueId;
+
+    @Column("assignee_id")
     private Long assigneeId;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueLabel.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/IssueLabel.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("issue_label")
@@ -13,8 +14,15 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder
 public class IssueLabel {
     @Id
+    @Column("issue_label_id")
     private Long id;
+
+    @Column("issue_id")
     private Long issueId;
+
+    @Column("label_id")
     private Long labelId;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Label.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Label.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("label")
@@ -13,10 +14,21 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder
 public class Label {
     @Id
+    @Column("label_id")
     private Long id;
+
+    @Column("name")
     private String name;
+
+    @Column("description")
     private String description;
+
+    @Column("color")
     private String color;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
+
+    @Column("updated_at")
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("milestone")
@@ -13,11 +14,24 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder
 public class Milestone {
     @Id
+    @Column("milestone_id")
     private Long id;
+
+    @Column("name")
     private String name;
+
+    @Column("description")
     private String description;
+
+    @Column("end_date")
     private LocalDateTime endDate;
+
+    @Column("is_open")
     private boolean isOpen;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
+
+    @Column("updated_at")
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/User.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/User.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
 @Table("user")
@@ -13,10 +14,21 @@ import org.springframework.data.relational.core.mapping.Table;
 @Builder
 public class User {
     @Id
+    @Column("user_id")
     private Long id;
+
+    @Column("email")
     private String email;
+
+    @Column("nickname")
     private String nickname;
+
+    @Column("profile_image")
     private String profileImage;
+
+    @Column("created_at")
     private LocalDateTime createdAt;
+
+    @Column("updated_at")
     private LocalDateTime updatedAt;
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/AssigneeNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/AssigneeNotFoundException.java
@@ -1,16 +1,12 @@
 package codesquad.team4.issuetracker.exception;
 
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_ASSIGNEE;
+
 import java.util.Set;
 
 public class AssigneeNotFoundException extends RuntimeException {
-    private final Set<Long> assigneeIds;
 
     public AssigneeNotFoundException(Set<Long> assigneeIds) {
-        super("존재하지 않는 assignee ID: " + assigneeIds);
-        this.assigneeIds = assigneeIds;
-    }
-
-    public Set<Long> getIssueId() {
-        return assigneeIds;
+        super(NOT_FOUND_ASSIGNEE + assigneeIds);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/AssigneeNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/AssigneeNotFoundException.java
@@ -1,0 +1,16 @@
+package codesquad.team4.issuetracker.exception;
+
+import java.util.Set;
+
+public class AssigneeNotFoundException extends RuntimeException {
+    private final Set<Long> assigneeIds;
+
+    public AssigneeNotFoundException(Set<Long> assigneeIds) {
+        super("존재하지 않는 assignee ID: " + assigneeIds);
+        this.assigneeIds = assigneeIds;
+    }
+
+    public Set<Long> getIssueId() {
+        return assigneeIds;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -6,4 +6,5 @@ public class ExceptionMessage {
     public static final String FILE_UPLOAD_FAILED = "파일 업로드에 실패했습니다.";
     public static final String UPDATE_ISSUE_FAILED =  "이슈가 존재하지 않습니다";
     public static final String NOT_FOUND_ISSUE = "이슈를 찾을 수 없습니다. issueId = ";
+    public static final String NOT_FOUND_MILESTONE = "마일스톤을 찾을 수 없습니다. milestoneId = ";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -7,4 +7,6 @@ public class ExceptionMessage {
     public static final String UPDATE_ISSUE_FAILED =  "이슈가 존재하지 않습니다";
     public static final String NOT_FOUND_ISSUE = "이슈를 찾을 수 없습니다. issueId = ";
     public static final String NOT_FOUND_MILESTONE = "마일스톤을 찾을 수 없습니다. milestoneId = ";
+    public static final String NOT_FOUND_LABEL = "존재하지 않는 label ID: ";
+    public static final String NOT_FOUND_ASSIGNEE = "존재하지 않는 assignee ID: ";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -14,16 +14,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IssueNotFoundException.class)
+    @ExceptionHandler({IssueNotFoundException.class, MilestoneNotFoundException.class})
     public ResponseEntity<ApiResponse<?>> handleIssueNotFoundException(IssueNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.fail(NOT_FOUND_ISSUE + ex.getIssueId()));
-    }
-
-    @ExceptionHandler(MilestoneNotFoundException.class)
-    public ResponseEntity<ApiResponse<?>> handleMilestoneNotFoundException(MilestoneNotFoundException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.fail(NOT_FOUND_MILESTONE + ex.getMilestoneId()));
+                .body(ApiResponse.fail(ex.getMessage()));
     }
 
     @ExceptionHandler(FileUploadException.class)

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package codesquad.team4.issuetracker.exception;
 
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.FILE_UPLOAD_FAILED;
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_ISSUE;
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_MILESTONE;
 
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,4 +20,15 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.fail(NOT_FOUND_ISSUE + ex.getIssueId()));
     }
 
+    @ExceptionHandler(MilestoneNotFoundException.class)
+    public ResponseEntity<ApiResponse<?>> handleMilestoneNotFoundException(MilestoneNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.fail(NOT_FOUND_MILESTONE + ex.getMilestoneId()));
+    }
+
+    @ExceptionHandler(FileUploadException.class)
+    public ResponseEntity<ApiResponse<?>> handleFileUploadException(FileUploadException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(FILE_UPLOAD_FAILED));
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({IssueNotFoundException.class, MilestoneNotFoundException.class})
-    public ResponseEntity<ApiResponse<?>> handleIssueNotFoundException(IssueNotFoundException ex) {
+    public ResponseEntity<ApiResponse<?>> handleNotFoundException(IssueNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.fail(ex.getMessage()));
     }
 
-    @ExceptionHandler(FileUploadException.class)
-    public ResponseEntity<ApiResponse<?>> handleFileUploadException(FileUploadException ex) {
+    @ExceptionHandler({FileUploadException.class, IssueStatusUpdateException.class})
+    public ResponseEntity<ApiResponse<?>> handleBadRequestException(FileUploadException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(FILE_UPLOAD_FAILED));
+                .body(ApiResponse.fail(ex.getMessage()));
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({IssueNotFoundException.class, MilestoneNotFoundException.class})
-    public ResponseEntity<ApiResponse<?>> handleNotFoundException(IssueNotFoundException ex) {
+    public ResponseEntity<ApiResponse<?>> handleNotFoundException(RuntimeException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ApiResponse.fail(ex.getMessage()));
     }
 
     @ExceptionHandler({FileUploadException.class, IssueStatusUpdateException.class})
-    public ResponseEntity<ApiResponse<?>> handleBadRequestException(FileUploadException ex) {
+    public ResponseEntity<ApiResponse<?>> handleBadRequestException(RuntimeException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(ex.getMessage()));
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/IssueNotFoundException.java
@@ -1,14 +1,10 @@
 package codesquad.team4.issuetracker.exception;
 
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_ISSUE;
+
 public class IssueNotFoundException extends RuntimeException {
-    private final Long issueId;
 
     public IssueNotFoundException(Long issueId) {
-        super("이슈를 찾을 수 없습니다. issueId = " + issueId);
-        this.issueId = issueId;
-    }
-
-    public Long getIssueId() {
-        return issueId;
+        super(NOT_FOUND_ISSUE + issueId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/LabelNotFoundException.java
@@ -1,0 +1,16 @@
+package codesquad.team4.issuetracker.exception;
+
+import java.util.Set;
+
+public class LabelNotFoundException extends RuntimeException {
+    private final Set<Long> labelIds;
+
+    public LabelNotFoundException(Set<Long> labelIds) {
+        super("존재하지 않는 label ID: " + labelIds);
+        this.labelIds = labelIds;
+    }
+
+    public Set<Long> getIssueId() {
+        return labelIds;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/LabelNotFoundException.java
@@ -1,16 +1,12 @@
 package codesquad.team4.issuetracker.exception;
 
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_LABEL;
+
 import java.util.Set;
 
 public class LabelNotFoundException extends RuntimeException {
-    private final Set<Long> labelIds;
 
     public LabelNotFoundException(Set<Long> labelIds) {
-        super("존재하지 않는 label ID: " + labelIds);
-        this.labelIds = labelIds;
-    }
-
-    public Set<Long> getIssueId() {
-        return labelIds;
+        super(NOT_FOUND_LABEL + labelIds);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/MilestoneNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/MilestoneNotFoundException.java
@@ -3,14 +3,8 @@ package codesquad.team4.issuetracker.exception;
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_MILESTONE;
 
 public class MilestoneNotFoundException extends RuntimeException {
-    private final Long milestoneId;
 
     public MilestoneNotFoundException(Long milestoneId) {
         super(NOT_FOUND_MILESTONE+ milestoneId);
-        this.milestoneId = milestoneId;
-    }
-
-    public Long getMilestoneId() {
-        return milestoneId;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/MilestoneNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/MilestoneNotFoundException.java
@@ -1,0 +1,16 @@
+package codesquad.team4.issuetracker.exception;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_FOUND_MILESTONE;
+
+public class MilestoneNotFoundException extends RuntimeException {
+    private final Long milestoneId;
+
+    public MilestoneNotFoundException(Long milestoneId) {
+        super(NOT_FOUND_MILESTONE+ milestoneId);
+        this.milestoneId = milestoneId;
+    }
+
+    public Long getMilestoneId() {
+        return milestoneId;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -31,37 +31,37 @@ public class IssueController {
     private final S3FileService s3FileService;
 
     @GetMapping("")
-    public ResponseEntity<IssueResponseDto.IssueListDto> showIssueList(@RequestParam(name = "is_open") boolean isOpen, Pageable pageable) {
+    public ResponseEntity<ApiResponse<IssueResponseDto.IssueListDto>> showIssueList(@RequestParam(name = "is_open") boolean isOpen, Pageable pageable) {
 
         IssueResponseDto.IssueListDto issues = issueService.getIssues(isOpen, pageable.getPageNumber(), pageable.getPageSize());
 
-        return ResponseEntity.ok(issues);
+        return ResponseEntity.ok(ApiResponse.success(issues));
     }
 
     @GetMapping("/count")
-    public ResponseEntity<IssueCountDto> showIssueCount() {
+    public ResponseEntity<ApiResponse<IssueCountDto>> showIssueCount() {
         IssueCountDto result = issueService.getIssueCounts();
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiMessageDto> createIssue(
+    public ResponseEntity<ApiResponse<IssueResponseDto.ApiMessageDto>> createIssue(
             @RequestPart("issue") @Valid IssueRequestDto.CreateIssueDto request,
             @RequestPart(value = "file", required = false) MultipartFile file) {
 
         String uploadUrl = s3FileService.uploadFile(file, ISSUE_DIRECTORY).orElse(EMPTY);
 
         ApiMessageDto result = issueService.createIssue(request, uploadUrl);
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     @PatchMapping("/status")
-    public ResponseEntity<IssueResponseDto.BulkUpdateIssueStatusDto> updateIssueStatus(
+    public ResponseEntity<ApiResponse<IssueResponseDto.BulkUpdateIssueStatusDto>> updateIssueStatus(
             @RequestBody IssueRequestDto.BulkUpdateIssueStatusDto requestDto) {
 
         IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
 
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     @GetMapping("/{issue-id}")

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -105,4 +105,12 @@ public class IssueController {
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }
+
+    @PutMapping("/{issueId}/assignees")
+    public ResponseEntity<ApiResponse<IssueResponseDto.ApiMessageDto>> updateIssueAssignees(@PathVariable Long issueId, @RequestBody IssueRequestDto.IssueAssigneeUpdateDto request) {
+
+        ApiMessageDto result = issueService.updateAssignees(issueId, request.getAssignees());
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -8,6 +8,7 @@ import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.CreateIssueDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import jakarta.validation.Valid;
 
@@ -83,6 +84,18 @@ public class IssueController {
     @GetMapping("/{issue-id}")
     public ResponseEntity<ApiResponse<IssueResponseDto.searchIssueDetailDto>> searchIssueDetail(@PathVariable("issue-id") Long issueId){
         IssueResponseDto.searchIssueDetailDto result = issueService.getIssueDetailById(issueId);
+
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping(value = "/{issue-id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<IssueResponseDto.CreateIssueDto>> updateIssue(
+            @PathVariable("issue-id") Long issueId,
+            @RequestPart("issue") @Valid IssueRequestDto.IssueUpdateDto request,
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+
+        String uploadUrl = s3FileService.uploadFile(file, ISSUE_DIRECTORY).orElse(EMPTY);
+        IssueResponseDto.CreateIssueDto result = issueService.updateIssue(issueId, request, uploadUrl);
 
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -48,16 +48,8 @@ public class IssueController {
     public ResponseEntity<ApiMessageDto> createIssue(
             @RequestPart("issue") @Valid IssueRequestDto.CreateIssueDto request,
             @RequestPart(value = "file", required = false) MultipartFile file) {
-        String uploadUrl;
 
-        try {
-            uploadUrl = s3FileService.uploadFile(file, ISSUE_DIRECTORY).orElse(EMPTY);
-        } catch (FileUploadException e) {
-            return ResponseEntity.badRequest().body(
-                    ApiMessageDto.builder()
-                    .message(ExceptionMessage.FILE_UPLOAD_FAILED)
-                    .build());
-        }
+        String uploadUrl = s3FileService.uploadFile(file, ISSUE_DIRECTORY).orElse(EMPTY);
 
         ApiMessageDto result = issueService.createIssue(request, uploadUrl);
         return ResponseEntity.ok(result);
@@ -66,17 +58,10 @@ public class IssueController {
     @PatchMapping("/status")
     public ResponseEntity<IssueResponseDto.BulkUpdateIssueStatusDto> updateIssueStatus(
             @RequestBody IssueRequestDto.BulkUpdateIssueStatusDto requestDto) {
-        try {
-            IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
-            return ResponseEntity.ok(result);
-        } catch (IssueStatusUpdateException e) {
-            return ResponseEntity.badRequest().body(
-                    IssueResponseDto.BulkUpdateIssueStatusDto.builder()
-                            .message(ExceptionMessage.UPDATE_ISSUE_FAILED)
-                            .build()
-            );
 
-        }
+        IssueResponseDto.BulkUpdateIssueStatusDto result = issueService.bulkUpdateIssueStatus(requestDto);
+
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/{issue-id}")

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -95,10 +95,4 @@
 
             return jdbcTemplate.queryForList(sql, issueId);
         }
-
-        public void deleteAllIssueLabelByIssueId(Long issueId) {
-            String sql = "DELETE FROM issue_label WHERE issue_id = :issueId";
-            Map<String, Object> params = Map.of("issueId", issueId);
-            namedParameterJdbcTemplate.update(sql, params);
-        }
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -96,10 +96,9 @@
             return jdbcTemplate.queryForList(sql, issueId);
         }
 
-        public void deleteAllByIssueId(Long issueId) {
+        public void deleteAllIssueLabelByIssueId(Long issueId) {
             String sql = "DELETE FROM issue_label WHERE issue_id = :issueId";
             Map<String, Object> params = Map.of("issueId", issueId);
             namedParameterJdbcTemplate.update(sql, params);
         }
-
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -7,6 +7,7 @@
 
     import lombok.RequiredArgsConstructor;
     import org.springframework.jdbc.core.JdbcTemplate;
+    import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
     import org.springframework.stereotype.Repository;
 
     @Repository
@@ -14,6 +15,7 @@
     public class IssueDao {
 
         private final JdbcTemplate jdbcTemplate;
+        private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
         public List<Map<String, Object>> findIssuesByOpenStatus(boolean isOpen, int page, int size){
             int offset = Math.max(0, (page - 1) * size);
@@ -92,6 +94,12 @@
             """;
 
             return jdbcTemplate.queryForList(sql, issueId);
+        }
+
+        public void deleteAllByIssueId(Long issueId) {
+            String sql = "DELETE FROM issue_label WHERE issue_id = :issueId";
+            Map<String, Object> params = Map.of("issueId", issueId);
+            namedParameterJdbcTemplate.update(sql, params);
         }
 
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -156,15 +156,7 @@ public class IssueService {
         }
 
         if(request.getAssigneeId() != null) {
-            for (Long assigneeId : request.getAssigneeId()) {
-                IssueAssignee issueAssignee = IssueAssignee.builder()
-                        .issueId(issueId)
-                        .assigneeId(assigneeId)
-                        .createdAt(LocalDateTime.now())
-                        .build();
-
-                issueAssigneeRepository.save(issueAssignee);
-            }
+            addNewAssignees(issueId, request.getAssigneeId());
         }
 
         return createMessageResult(issueId, CREATE_ISSUE);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -286,7 +286,7 @@ public class IssueService {
         validateLabelIdsExist(labelIds);
 
         // 기존 매핑 삭제
-        issueDao.deleteAllIssueLabelByIssueId(issueId);
+        labelDao.deleteAllIssueLabelByIssueId(issueId);
 
         // 새 레이블 매핑 추가
         addNewLabels(issueId, labelIds);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -30,4 +30,14 @@ public class IssueRequestDto {
         private List<Long> issuesId;
         private boolean isOpen;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class IssueUpdateDto {
+        private String title;
+        private String content;
+        private Long milestoneId;
+        private Boolean isOpen;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -49,4 +49,11 @@ public class IssueRequestDto {
     public static class IssueLabelsUpdateDto {
         private Set<Long> labels;
     }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class IssueAssigneeUpdateDto {
+        private Set<Long> assignees;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.issue.dto;
 
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +19,8 @@ public class IssueRequestDto {
         private String content;
         @NotNull
         private Long authorId;
-        private List<Long> assigneeId;
-        private List<Long> labelId;
+        private Set<Long> assigneeId;
+        private Set<Long> labelId;
         private Long milestoneId;
     }
 
@@ -40,5 +41,12 @@ public class IssueRequestDto {
         private Long milestoneId;
         private Boolean isOpen;
         private Boolean removeImage;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class IssueLabelsUpdateDto {
+        private Set<Long> labels;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -39,5 +39,6 @@ public class IssueRequestDto {
         private String content;
         private Long milestoneId;
         private Boolean isOpen;
+        private Boolean removeImage;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -40,7 +40,7 @@ public class IssueResponseDto {
     @AllArgsConstructor
     @Getter
     @Builder
-    public static class CreateIssueDto {
+    public static class ApiMessageDto {
         private Long id;
         private String message;
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/IssueLabelRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/IssueLabelRepository.java
@@ -2,7 +2,9 @@ package codesquad.team4.issuetracker.label;
 
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueLabel;
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 
 public interface IssueLabelRepository extends CrudRepository<IssueLabel, Long> {
+    List<IssueLabel> findAllByIssueId(Long issueId);
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -1,6 +1,8 @@
 package codesquad.team4.issuetracker.label;
 
 import codesquad.team4.issuetracker.label.dto.LabelDto;
+import codesquad.team4.issuetracker.label.dto.LabelDto.LabelFilter;
+import codesquad.team4.issuetracker.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,9 +16,9 @@ public class LabelController {
     private final LabelService labelService;
 
     @GetMapping("/filter")
-    public ResponseEntity<LabelDto.LabelFilter> getFilterLabels() {
+    public ResponseEntity<ApiResponse<LabelFilter>> getFilterLabels() {
         LabelDto.LabelFilter result = labelService.getFilterLabels();
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
@@ -1,10 +1,12 @@
 package codesquad.team4.issuetracker.label;
 
 import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Repository;
 public class LabelDao {
 
     private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public List<LabelDto.LabelInfo> findLabelForFiltering() {
         String sql = "SELECT label_id, name, color FROM label";
@@ -23,5 +26,12 @@ public class LabelDao {
                         .color(rs.getString("color"))
                         .build()
         );
+    }
+
+    public List<Long> findExistingLabelIds(Set<Long> labelIds) {
+        String sql = "SELECT label_id FROM label WHERE label_id IN (:ids)";
+        Map<String, Object> params = Map.of("ids", labelIds);
+
+        return namedParameterJdbcTemplate.queryForList(sql, params, Long.class);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
@@ -28,6 +28,12 @@ public class LabelDao {
         );
     }
 
+    public void deleteAllIssueLabelByIssueId(Long issueId) {
+        String sql = "DELETE FROM issue_label WHERE issue_id = :issueId";
+        Map<String, Object> params = Map.of("issueId", issueId);
+        namedParameterJdbcTemplate.update(sql, params);
+    }
+
     public List<Long> findExistingLabelIds(Set<Long> labelIds) {
         String sql = "SELECT label_id FROM label WHERE label_id IN (:ids)";
         Map<String, Object> params = Map.of("ids", labelIds);

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
@@ -1,6 +1,8 @@
 package codesquad.team4.issuetracker.milestone;
 
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneDto.MilestoneFilter;
+import codesquad.team4.issuetracker.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,9 +16,9 @@ public class MilestoneController {
     private final MilestoneService milestoneService;
 
     @GetMapping("/filter")
-    public ResponseEntity<MilestoneDto.MilestoneFilter> getFilterMilestones() {
+    public ResponseEntity<ApiResponse<MilestoneFilter>> getFilterMilestones() {
         MilestoneDto.MilestoneFilter result = milestoneService.getFilterMilestones();
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneRepository.java
@@ -1,0 +1,8 @@
+package codesquad.team4.issuetracker.milestone;
+
+import codesquad.team4.issuetracker.entity.Issue;
+import codesquad.team4.issuetracker.entity.Milestone;
+import org.springframework.data.repository.CrudRepository;
+
+public interface MilestoneRepository extends CrudRepository<Milestone, Long> {
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/user/IssueAssigneeRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/user/IssueAssigneeRepository.java
@@ -1,7 +1,9 @@
 package codesquad.team4.issuetracker.user;
 
 import codesquad.team4.issuetracker.entity.IssueAssignee;
+import java.util.List;
 import org.springframework.data.repository.CrudRepository;
 
 public interface IssueAssigneeRepository extends CrudRepository<IssueAssignee, Long> {
+    List<IssueAssignee> findAllByIssueId(Long issueId);
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/user/UserController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/user/UserController.java
@@ -1,6 +1,8 @@
 package codesquad.team4.issuetracker.user;
 
+import codesquad.team4.issuetracker.response.ApiResponse;
 import codesquad.team4.issuetracker.user.dto.UserDto;
+import codesquad.team4.issuetracker.user.dto.UserDto.UserFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,9 +16,9 @@ public class UserController {
     private final UserService userService;
 
     @GetMapping("/filter")
-    public ResponseEntity<UserDto.UserFilter> getFilterUsers() {
+    public ResponseEntity<ApiResponse<UserFilter>> getFilterUsers() {
         UserDto.UserFilter result = userService.getFilterUsers();
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/user/UserDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/user/UserDao.java
@@ -2,8 +2,11 @@ package codesquad.team4.issuetracker.user;
 
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Repository;
 public class UserDao {
 
     private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public List<UserDto.UserInfo> findUserForFiltering() {
         String sql = "SELECT user_id, nickname, profile_image FROM `user`";
@@ -22,5 +26,18 @@ public class UserDao {
                         .profileImage(rs.getString("profile_image"))
                         .build()
         );
+    }
+
+    public void deleteAllByIssueId(Long issueId) {
+        String sql = "DELETE FROM issue_assignee WHERE issue_id = :issueId";
+        Map<String, Object> params = Map.of("issueId", issueId);
+        namedParameterJdbcTemplate.update(sql, params);
+    }
+
+    public List<Long> findExistingAssigneeIds(Set<Long> assigneeIds) {
+        String sql = "SELECT user_id FROM `user` WHERE user_id IN (:ids)";
+        Map<String, Object> params = Map.of("ids", assigneeIds);
+
+        return namedParameterJdbcTemplate.queryForList(sql, params, Long.class);
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -7,6 +7,7 @@ import codesquad.team4.issuetracker.exception.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Optional;
@@ -62,7 +63,7 @@ class IssueControllerTest {
 
         given(s3FileService.uploadFile(any(), eq("issue/"))).willReturn(Optional.of("https://fake-s3-url/image.png"));
 
-        IssueResponseDto.CreateIssueDto responseDto = IssueResponseDto.CreateIssueDto.builder()
+        ApiMessageDto responseDto = ApiMessageDto.builder()
                 .id(1L)
                 .message("이슈가 생성되었습니다.")
                 .build();

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -76,8 +76,8 @@ class IssueControllerTest {
                         .file(file)
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.message").value("이슈가 생성되었습니다."));
+                .andExpect(jsonPath("$.data.id").value(1L))
+                .andExpect(jsonPath("$.data.message").value("이슈가 생성되었습니다."));
     }
 
     @Test
@@ -129,10 +129,10 @@ class IssueControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.issuesId[0]").value(1))
-                .andExpect(jsonPath("$.issuesId[1]").value(2))
-                .andExpect(jsonPath("$.issuesId[2]").value(3))
-                .andExpect(jsonPath("$.message").value("이슈 상태가 변경되었습니다."));
+                .andExpect(jsonPath("$.data.issuesId[0]").value(1))
+                .andExpect(jsonPath("$.data.issuesId[1]").value(2))
+                .andExpect(jsonPath("$.data.issuesId[2]").value(3))
+                .andExpect(jsonPath("$.data.message").value("이슈 상태가 변경되었습니다."));
     }
 
     @Test
@@ -153,7 +153,7 @@ class IssueControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(requestDto)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("이슈가 존재하지 않습니다"));
+                .andExpect(jsonPath("$.message").value("일부 이슈 ID가 존재하지 않습니다."));
     }
 
     @Test

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -12,10 +12,9 @@ import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
 import codesquad.team4.issuetracker.entity.IssueLabel;
 import codesquad.team4.issuetracker.exception.IssueNotFoundException;
-import codesquad.team4.issuetracker.exception.IssueStatusUpdateException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
-import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.CreateIssueDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
 import java.sql.Timestamp;
@@ -84,7 +83,7 @@ public class IssueServiceTest {
         given(issueRepository.save(any(Issue.class))).willReturn(issue);
 
         // when
-        CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
+        ApiMessageDto response = issueService.createIssue(requestDto, uploadUrl);
 
         // then
         assertThat(response).isNotNull();
@@ -120,7 +119,7 @@ public class IssueServiceTest {
         given(issueRepository.save(any(Issue.class))).willReturn(issue);
 
         // when
-        CreateIssueDto response = issueService.createIssue(requestDto, uploadUrl);
+        ApiMessageDto response = issueService.createIssue(requestDto, uploadUrl);
 
         // then
         assertThat(response).isNotNull();

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,8 +59,8 @@ public class IssueServiceTest {
                 .content("Test Content")
                 .authorId(1L)
                 .milestoneId(null)
-                .labelId(List.of(1L, 2L))
-                .assigneeId(List.of(1L, 2L));
+                .labelId(Set.of(1L, 2L))
+                .assigneeId(Set.of(1L, 2L));
     }
 
     @Test

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceUpdateTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceUpdateTest.java
@@ -1,11 +1,10 @@
 package codesquad.team4.issuetracker.issue;
 
 import codesquad.team4.issuetracker.entity.Issue;
-import codesquad.team4.issuetracker.entity.Milestone;
 import codesquad.team4.issuetracker.exception.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.MilestoneNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
-import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.milestone.MilestoneRepository;
 import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
@@ -19,8 +18,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-import static codesquad.team4.issuetracker.util.TestDataHelper.insertIssueAllParams;
-import static codesquad.team4.issuetracker.util.TestDataHelper.insertMilestone;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -69,7 +66,7 @@ class IssueServiceUpdateTest {
                 .build();
 
         //when
-        IssueResponseDto.CreateIssueDto result = issueService.updateIssue(1L, request, "");
+        ApiMessageDto result = issueService.updateIssue(1L, request, "");
 
         Issue updated = issueRepository.findById(1L).get();
 

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceUpdateTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceUpdateTest.java
@@ -1,0 +1,142 @@
+package codesquad.team4.issuetracker.issue;
+
+import codesquad.team4.issuetracker.entity.Issue;
+import codesquad.team4.issuetracker.entity.Milestone;
+import codesquad.team4.issuetracker.exception.IssueNotFoundException;
+import codesquad.team4.issuetracker.exception.MilestoneNotFoundException;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.label.IssueLabelRepository;
+import codesquad.team4.issuetracker.milestone.MilestoneRepository;
+import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
+import codesquad.team4.issuetracker.util.TestDataHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static codesquad.team4.issuetracker.util.TestDataHelper.insertIssueAllParams;
+import static codesquad.team4.issuetracker.util.TestDataHelper.insertMilestone;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+class IssueServiceUpdateTest {
+
+    @Autowired
+    private IssueService issueService;
+
+    @Autowired
+    private IssueDao issueDao;
+
+    @Autowired
+    private IssueLabelRepository issueLabelRepository;
+
+    @Autowired
+    private IssueAssigneeRepository issueAssigneeRepository;
+
+    @Autowired
+    private IssueRepository issueRepository;
+
+    @Autowired
+    private MilestoneRepository milestoneRepository;
+    private static final String OLD_IMAGE = "http://s3.com/old.png";
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @BeforeEach
+    void setUp() {
+        TestDataHelper.insertUser(jdbcTemplate, 1L, "사용자1");
+        TestDataHelper.insertIssueAllParams(jdbcTemplate, 1L, "이슈 1", true, 1L, "본문", "http://s3.com/old.png", null);
+        TestDataHelper.insertMilestone(jdbcTemplate, 1L, "v1.0", "First release", null, true);
+    }
+
+    @Test
+    @DisplayName("이슈가 정상적으로 수정되어야한다")
+    void updateIssueSuccess() {
+        //given
+        IssueRequestDto.IssueUpdateDto request = IssueRequestDto.IssueUpdateDto.builder()
+                .title("Updated title")
+                .content("Updated content")
+                .milestoneId(1L)
+                .isOpen(false)
+                .removeImage(false)
+                .build();
+
+        //when
+        IssueResponseDto.CreateIssueDto result = issueService.updateIssue(1L, request, "");
+
+        Issue updated = issueRepository.findById(1L).get();
+
+        //then
+        assertThat(result.getMessage()).isEqualTo("이슈가 수정되었습니다");
+        assertThat(updated.getTitle()).isEqualTo("Updated title");
+        assertThat(updated.getContent()).isEqualTo("Updated content");
+        assertThat(updated.getMilestoneId()).isEqualTo(1L);
+        assertThat(updated.isOpen()).isFalse();
+    }
+
+    @Test
+    @DisplayName("잘못된 이슈 번호를 입력하면 에러가 발생한다")
+    void throwWhenIssueIdIsInvalid() {
+        //given
+        IssueRequestDto.IssueUpdateDto request = IssueRequestDto.IssueUpdateDto.builder().build();
+
+        //when & then
+        assertThatThrownBy(() -> issueService.updateIssue(999L, request, ""))
+                .isInstanceOf(IssueNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("잘못된 마일스톤 번호를 입력하면 에러가 발생한다")
+    void throwWhenMilestoneIdIsInvalid() {
+        IssueRequestDto.IssueUpdateDto request = IssueRequestDto.IssueUpdateDto.builder()
+                .milestoneId(999L)
+                .build();
+
+        assertThatThrownBy(() -> issueService.updateIssue(1L, request, ""))
+                .isInstanceOf(MilestoneNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("removeImage가 true이면 imageUrl이 null이어야한다")
+    void removeImageWhenRequested() {
+        IssueRequestDto.IssueUpdateDto request = IssueRequestDto.IssueUpdateDto.builder()
+                .removeImage(true)
+                .build();
+
+        issueService.updateIssue(1L, request, "");
+
+        assertThat(issueRepository.findById(1L).get().getImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("removeImage가 false면 이전 imageUrl이 유지되어야 한다")
+    void keepImageWhenRemoveFalse() {
+        IssueRequestDto.IssueUpdateDto request = IssueRequestDto.IssueUpdateDto.builder()
+                .removeImage(false)
+                .build();
+
+        issueService.updateIssue(1L, request, "");
+
+        assertThat(issueRepository.findById(1L).get().getImageUrl()).isEqualTo(OLD_IMAGE);
+    }
+
+    @Test
+    @DisplayName("removeImage가 true지만 원래 이미지가 없을 때는 기존 상태를 유지한다")
+    void removeImageWhenAlreadyNull() {
+        IssueRequestDto.IssueUpdateDto request = IssueRequestDto.IssueUpdateDto.builder()
+                .removeImage(true)
+                .build();
+
+        issueService.updateIssue(1L, request, "");
+
+        assertThat(issueRepository.findById(1L).get().getImageUrl()).isNull();
+    }
+
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
@@ -30,4 +30,11 @@ public class TestDataHelper {
         VALUES (?, ?, ?, ?, ?)
     """, id, name, description, endDate, isOpen);
     }
+
+    public static void insertLabel(JdbcTemplate jdbcTemplate, Long id, String title, String color) {
+        jdbcTemplate.update("""
+        INSERT INTO label (label_id, name, color)
+        VALUES (?, ?, ?)
+    """, id, title, color);
+    }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.util;
 
+import java.time.LocalDateTime;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 public class TestDataHelper {
@@ -16,5 +17,17 @@ public class TestDataHelper {
             INSERT INTO issue (issue_id, title, is_open, author_id)
             VALUES (?, ?, ?, ?)
         """, id, title, isOpen, authorId);
+    }
+    public static void insertIssueAllParams(JdbcTemplate jdbcTemplate, Long id, String title, boolean isOpen, Long authorId, String content, String imageUrl, Long milestoneId) {
+        jdbcTemplate.update("""
+        INSERT INTO issue (issue_id, title, is_open, author_id, content, image_url, milestone_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    """, id, title, isOpen, authorId, content, imageUrl, milestoneId);
+    }
+    public static void insertMilestone(JdbcTemplate jdbcTemplate, Long id, String name, String description, LocalDateTime endDate, Boolean isOpen) {
+        jdbcTemplate.update("""
+        INSERT INTO milestone (milestone_id, name, description, end_date, is_open)
+        VALUES (?, ?, ?, ?, ?)
+    """, id, name, description, endDate, isOpen);
     }
 }

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    url: jdbc:h2:mem:testdb;DATABASE_TO_UPPER=false;MODE=MySQL
     driver-class-name: org.h2.Driver
     username: sa
     password:


### PR DESCRIPTION
🔥 작업 내용 요약
	•	이슈 수정 관련 기능 전반 구현 (제목, 내용, 이미지, 상태, 레이블, 담당자)
	•	공통 예외 처리 방식 개선
	•	테스트 코드 추가 및 리팩토링

⸻

✅ 작업 상세 내용
- 이슈 수정 기능 구현
	    •	PATCH /api/issues/{id}: 이슈의 제목, 내용, 이미지 URL, 상태(open/closed) 수정 API 구현
	    •	PUT /api/issues/{id}/labels: 이슈에 연결된 레이블 수정 API 구현
	    •	PUT /api/issues/{id}/assignees: 이슈 담당자 수정 API 구현
	    •	테스트 코드 작성
	    •	이슈 업데이트에 대한 통합 테스트 추가
	    •	레이블, 담당자 수정 API에 대한 정상/예외 케이스 테스트 작성
- @ControllerAdvice를 통해 전역 예외 처리 설정
	•	IssueNotFoundException, MilestoneNotFoundException 등 공통 NotFound 계열 예외 하나의 핸들러에서 처리
	•	커스텀 예외 클래스에서 getter 제거 및 메시지 중심 처리로 간결화
- DB 관련
	•	H2 DB에서 컬럼 대소문자 구분 문제 해결을 위한 @Column 어노테이션 명시
	•	SQL 예약어 충돌 방지를 위해 "user" 테이블명 처리 수정
- ResponseEntity<ApiResponse<?>> 기반으로 컨트롤러 반환 형식 통일
