### PR TITLE
[FEAT] 댓글 삭제 기능

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
@@ -7,13 +7,9 @@ import codesquad.team4.issuetracker.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
@@ -47,5 +43,11 @@ public class CommentController {
 
         CommentResponseDto.UpdateCommentDto response = commentService.updateComment(commentId, request, uploadUrl);
         return ApiResponse.success(response);
+    }
+
+    @DeleteMapping("/{issue-id}/{cpmment-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteComment(@PathVariable("issue-id") Long issueId, @PathVariable("comment-id") Long commentId) {
+        commentService.deleteComment(issueId, commentId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
@@ -3,6 +3,7 @@ package codesquad.team4.issuetracker.comment;
 import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Comment;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidCommentAccessException;
 import codesquad.team4.issuetracker.exception.notfound.CommentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,5 +53,16 @@ public class CommentService {
                 .id(commentId)
                 .message(UPDATE_COMMENT)
                 .build();
+    }
+
+    public void deleteComment(Long issueId, Long commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CommentNotFoundException(commentId));
+
+        if (!comment.getIssueId().equals(issueId)) {
+            throw new InvalidCommentAccessException(); // 선택사항
+        }
+
+        commentRepository.deleteById(commentId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -10,4 +10,5 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_LABEL = "존재하지 않는 label ID: ";
     public static final String NOT_FOUND_ASSIGNEE = "존재하지 않는 assignee ID: ";
     public static final String NOT_FOUND_COMMENT = "댓글을 찾을 수 없습니다. commentId = ";
+    public static final String INVALID_COMMENT_ACCESS = "댓글이 이슈에 속하지 않습니다.";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidCommentAccessException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidCommentAccessException.java
@@ -1,0 +1,9 @@
+package codesquad.team4.issuetracker.exception.badrequest;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.INVALID_COMMENT_ACCESS;
+
+public class InvalidCommentAccessException extends InvalidRequestException {
+    public InvalidCommentAccessException() {
+        super(INVALID_COMMENT_ACCESS);
+    }
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/comment/CommentServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/comment/CommentServiceTest.java
@@ -1,12 +1,5 @@
 package codesquad.team4.issuetracker.comment;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.entity.Comment;
@@ -21,6 +14,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class CommentServiceTest {
@@ -148,6 +148,43 @@ public class CommentServiceTest {
                 commentService.updateComment(commentId, request, "dummy.png")
         ).isInstanceOf(CommentNotFoundException.class)
                 .hasMessageContaining("댓글을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 성공")
+    void testDeleteComment_success() {
+        // given
+        Long issueId = 1L;
+        Long commentId = 2L;
+
+        Comment comment = Comment.builder()
+                .id(commentId)
+                .issueId(issueId)
+                .authorId(1L)
+                .content("삭제할 댓글.")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+
+        // when
+        commentService.deleteComment(issueId, commentId);
+
+        // then
+        verify(commentRepository, times(1)).findById(commentId);
+        verify(commentRepository, times(1)).deleteById(commentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 댓글을 삭제하려 하면 에러가 발생한다")
+    void deleteNotExistComment() {
+        //given
+        Long issueId = 1L;
+        Long commentId = 999L;
+
+        //when & then
+        assertThatThrownBy(() -> commentService.deleteComment(issueId, commentId))
+                .isInstanceOf(CommentNotFoundException.class);
     }
 
 }


### PR DESCRIPTION
🔥 작업 내용 요약

* 댓글 삭제 구현

✅ 작업 상세 내용

* 댓글 삭제 기능
* 이슈에 댓글이 존재하지 않을 경우 오류 발생
* 서비스 단위 테스트 작성
