### PR TITLE
[Chore] Swagger 설정

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.25.3')
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentController.java
@@ -45,7 +45,7 @@ public class CommentController {
         return ApiResponse.success(response);
     }
 
-    @DeleteMapping("/{issue-id}/{cpmment-id}")
+    @DeleteMapping("/{issue-id}/{comment-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteComment(@PathVariable("issue-id") Long issueId, @PathVariable("comment-id") Long commentId) {
         commentService.deleteComment(issueId, commentId);

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/SwaggerConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package codesquad.team4.issuetracker.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@OpenAPIDefinition(
+    info = @Info(title = "Issue Tracker API", version = "v1", description = "이슈 및 댓글 관리 API 문서입니다.")
+)
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI api() {
+        SecurityScheme apiKey = new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization")
+            .scheme("bearer")
+            .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList("Bearer Token");
+
+        return new OpenAPI()
+            .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+            .addSecurityItem(securityRequirement);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -3,11 +3,13 @@ package codesquad.team4.issuetracker.exception;
 import codesquad.team4.issuetracker.exception.badrequest.InvalidRequestException;
 import codesquad.team4.issuetracker.exception.notfound.DataNotFoundException;
 import codesquad.team4.issuetracker.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,3 +27,10 @@ cloud:
 logging:
   level:
     root: INFO
+
+springdoc:
+    api-docs:
+        path: /issue-tracker/api-docs
+    swagger-ui:
+        path: /issue-tracker/swagger-ui.html
+        url: /issue-tracker/api-docs


### PR DESCRIPTION
## ✨ 작업 내용
- Swagger 설정
- ControlAdvice 응답 구조 swagger가 반영 못 함 -> `@Hidden` 으로 swagger에서 무시
- Swagger UI 기본 경로(`/swagger-ui.html`, `/v3/api-docs`)를 `/issue-tracker/` 하위로 변경
    - 운영 환경에서 Swagger 문서가 외부에 노출되지 않도록 하기 위함
    - 로컬:  http://localhost:8080/issue-tracker/swagger-ui.html
    - 배포: http://(EC2 퍼블릭 IP)/issue-tracker/swagger-ui.html

## 고려사항
-  배포 시 Swagger가 정상 동작하려면 Nginx 리버스 프록시 설정에 다음 경로 추가해야 함.
```server {
    listen 80;
    server_name your.domain.com;

    # 프론트엔드 정적 파일 (예: React)
    location / {
        root /usr/share/nginx/html;
        index index.html;
        try_files $uri /index.html;
    }

    # ✅ Swagger UI 요청 프록시
    location /issue-tracker/ {
        proxy_pass http://localhost:8080/issue-tracker/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
    }

    # ✅ Swagger JSON 문서 요청 프록시
    location /issue-tracker/api-docs {
        proxy_pass http://localhost:8080/issue-tracker/api-docs;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
    }
}```


