### PR TITLE
[Test] 이슈 목록 필터링 테스트

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -11,4 +11,5 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_ASSIGNEE = "존재하지 않는 assignee ID: ";
     public static final String NOT_FOUND_COMMENT = "댓글을 찾을 수 없습니다. commentId = ";
     public static final String INVALID_COMMENT_ACCESS = "댓글이 이슈에 속하지 않습니다.";
+    public static final String INVALID_FILTERING_CONDITION = "authorId, assigneeId, commentAuthorId 중 하나만 사용할 수 있습니다.";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidFilteringConditionException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/InvalidFilteringConditionException.java
@@ -1,0 +1,8 @@
+package codesquad.team4.issuetracker.exception.badrequest;
+
+public class InvalidFilteringConditionException extends InvalidRequestException {
+    public InvalidFilteringConditionException(String message) {
+        super(message);
+    }
+
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -1,12 +1,18 @@
 package codesquad.team4.issuetracker.issue;
 
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.INVALID_FILTERING_CONDITION;
+
 import codesquad.team4.issuetracker.aws.S3FileService;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidFilteringConditionException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -38,10 +44,22 @@ public class IssueController {
 
     @GetMapping("")
     public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(@Valid IssueRequestDto.IssueFilterParamDto params, Pageable pageable) {
+        //authorId, assigneeId, commentAuthorId 중 두개 이상의 조건은 불가
+        validateFilterConditionCount(params);
 
         IssueResponseDto.IssueListDto issues = issueService.getIssues(params, pageable.getPageNumber(), pageable.getPageSize());
 
         return ApiResponse.success(issues);
+    }
+
+    private void validateFilterConditionCount(IssueFilterParamDto params) {
+        long filterCount = Stream.of(params.getAuthorId(), params.getAssigneeId(), params.getCommentAuthorId())
+            .filter(Objects::nonNull)
+            .count();
+
+        if (filterCount > 1) {
+            throw new InvalidFilteringConditionException(INVALID_FILTERING_CONDITION);
+        }
     }
 
     @GetMapping("/count")

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -6,21 +6,21 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueCountDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
+import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
+import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.util.TestDataHelper;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest
@@ -111,8 +111,11 @@ class IssueServiceH2Test {
         TestDataHelper.insertIssueAssignee(jdbcTemplate, 2L, 1L, 2L);
         TestDataHelper.insertIssueAssignee(jdbcTemplate, 3L, 2L, 1L);
 
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(true)
+            .build();
         //when
-        IssueResponseDto.IssueListDto actual = issueService.getIssues(true, 0, 2);
+        IssueResponseDto.IssueListDto actual = issueService.getIssues(param, 0, 2);
 
         //then
         assertThat(actual.getIssues()).hasSize(2);
@@ -133,5 +136,128 @@ class IssueServiceH2Test {
         //when & then
         assertThatThrownBy(() -> issueService.deleteIssue(issueId))
                 .isInstanceOf(IssueNotFoundException.class);
+    }
+
+    @ParameterizedTest
+    @DisplayName("필터링 조건이 내가 작성한 이슈를 가져오는 경우 다른 사람이 작성한 이슈는 가져와서는 안된다")
+    @CsvSource({
+                "true, 3, 1",
+                "false, 1, 1",
+                "true, 1, 2",
+                "false, 1, 2"})
+    void filterIssueByAuthor(boolean isOpen, int expectedSize, Long authorId) {
+        //given
+        TestDataHelper.insertUser(jdbcTemplate, 2L, "사용자2");
+        TestDataHelper.insertIssue(jdbcTemplate, 4L, "이슈 4", true, 1L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 5L, "이슈 5", true, 2L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 6L, "이슈 6", false, 2L);  // closed
+
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(isOpen)
+            .authorId(authorId)
+            .build();
+        //when
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(param, 0, 10);
+
+        //then
+        assertThat(issues.getIssues()).hasSize(expectedSize);
+        assertThat(issues.getIssues())
+            .allSatisfy(issue -> assertThat(issue.getAuthor().getId()).isEqualTo(authorId));
+    }
+
+    @ParameterizedTest
+    @DisplayName("필터링 조건이 내가 담당한 이슈를 가져오는 경우 내가 담당하지 않은 이슈는 가져와서는 안된다")
+    @CsvSource({
+        "true, 1, 1",
+        "false, 0, 1",
+        "true, 1, 2",
+        "false, 1, 2",
+        "true, 2, 3",
+        "false, 0, 3"})
+    void filterIssueByAssignee(boolean isOpen, int expectedSize, Long assigneeId) {
+        //given
+        TestDataHelper.insertUser(jdbcTemplate, 2L, "사용자2");
+        TestDataHelper.insertUser(jdbcTemplate, 3L, "사용자3");
+
+        TestDataHelper.insertIssue(jdbcTemplate, 4L, "이슈 4", true, 1L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 5L, "이슈 5", true, 2L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 6L, "이슈 6", false, 2L);  // closed
+
+        //담당자 설정
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 1L, 1L, 1L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 2L, 1L, 2L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 3L, 3L, 2L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 4L, 1L, 3L);
+        TestDataHelper.insertIssueAssignee(jdbcTemplate, 5L, 4L, 3L);
+
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(isOpen)
+            .assigneeId(assigneeId)
+            .build();
+        //when
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(param, 0, 10);
+
+        //then
+        assertThat(issues.getIssues()).hasSize(expectedSize);
+        assertThat(issues.getIssues())
+            .allSatisfy(issue ->
+                assertThat(issue.getAssignees().stream()
+                    .anyMatch(assignee -> assignee.getId().equals(assigneeId)))
+                    .isTrue()
+            );
+    }
+
+    @ParameterizedTest
+    @DisplayName("필터링 조건이 내가 댓글을 작성한 이슈를 가져오는 경우 댓글을 달지 않은 이슈는 가져와서는 안된다")
+    @CsvSource({
+        "true, 1, 1",
+        "false, 0, 1",
+        "true, 1, 2",
+        "false, 1, 2",
+        "true, 0, 3",
+        "false, 2, 3"
+    })
+    void filterIssueByCommentAuthor(boolean isOpen, int expectedSize, Long commentAuthorId) {
+        // given
+        TestDataHelper.insertUser(jdbcTemplate, 2L, "사용자2");
+        TestDataHelper.insertUser(jdbcTemplate, 3L, "사용자3");
+
+        TestDataHelper.insertIssue(jdbcTemplate, 4L, "이슈 4", true, 1L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 5L, "이슈 5", true, 2L);   // open
+        TestDataHelper.insertIssue(jdbcTemplate, 6L, "이슈 6", false, 2L);  // closed
+
+        // 댓글 작성
+        TestDataHelper.insertComment(jdbcTemplate, 1L, "댓글1", 1L, 1L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 2L, "댓글2", 2L, 2L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 3L, "댓글3", 2L, 3L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 4L, "댓글4", 3L, 3L, null);
+        TestDataHelper.insertComment(jdbcTemplate, 5L, "댓글5", 3L, 6L, null);
+
+        IssueFilterParamDto param = IssueFilterParamDto.builder()
+            .isOpen(isOpen)
+            .commentAuthorId(commentAuthorId)
+            .build();
+
+        // when
+        IssueResponseDto.IssueListDto issues = issueService.getIssues(param, 0, 10);
+
+        //필터링한 이슈 아이디와 DB에서 조회한 이슈 아이디가 일치하는지 확인
+        List<Long> actualIssueIds = issues.getIssues().stream()
+            .map(IssueInfo::getId)
+            .toList();
+
+        String sql = """
+            SELECT DISTINCT c.issue_id
+            FROM comment c
+            JOIN issue i ON c.issue_id = i.issue_id
+            WHERE c.author_id = ?
+            AND i.is_open = ?
+        """;
+
+        List<Long> expectedIssueIds = jdbcTemplate.queryForList(sql, Long.class, commentAuthorId, isOpen);
+
+        // then
+        assertThat(issues.getIssues()).hasSize(expectedSize);
+        assertThat(actualIssueIds).containsExactlyInAnyOrderElementsOf(expectedIssueIds);
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
@@ -51,5 +51,10 @@ public class TestDataHelper {
             VALUES (?, ?, ?)
         """, id, issueId, assigneeId);
     }
-
+    public static void insertComment(JdbcTemplate jdbcTemplate, Long id, String content, Long authorId, Long issueId, String fileUrl) {
+        jdbcTemplate.update("""
+        INSERT INTO comment (comment_id, content, author_id, issue_id, file_url)
+        VALUES (?, ?, ?, ?, ?)
+    """, id, content, authorId, issueId, fileUrl);
+    }
 }


### PR DESCRIPTION
🔥 작업 내용 요약

-  필터링 조건 2개 이상인 경우 검증 로직 작성
- 필터링 검색 테스트 작성
⸻

✅ 작업 상세 내용
	•	이슈 필터링 기능 테스트 케이스 작성
	•	authorId, assigneeId, commentAuthorId 중 하나만 존재해야 하는 비즈니스 로직 검증
	•	필터링 조건이 2개 이상 존재할 경우 400 Bad Request를 반환하도록 컨트롤러 레벨 테스트 추가
	•	isOpen이 존재하지 않는 경우의 테스트 케이스도 별도로 작성 예정