### PR TITLE
[FEAT]  레이블/마일스톤 상세 기능 구현

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/comment/CommentService.java
@@ -55,6 +55,7 @@ public class CommentService {
                 .build();
     }
 
+    @Transactional
     public void deleteComment(Long issueId, Long commentId) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentNotFoundException(commentId));

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.entity;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,7 +25,7 @@ public class Milestone {
     private String description;
 
     @Column("end_date")
-    private LocalDateTime endDate;
+    private LocalDate endDate;
 
     @Column("is_open")
     private boolean isOpen;

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/Milestone.java
@@ -35,4 +35,8 @@ public class Milestone {
 
     @Column("updated_at")
     private LocalDateTime updatedAt;
+
+    public void updateStatus(boolean isOpen) {
+        this.isOpen = isOpen;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/notfound/LabelNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/notfound/LabelNotFoundException.java
@@ -9,4 +9,6 @@ public class LabelNotFoundException extends DataNotFoundException {
     public LabelNotFoundException(Set<Long> labelIds) {
         super(NOT_FOUND_LABEL + labelIds);
     }
+
+    public LabelNotFoundException(Long labelId) { super(NOT_FOUND_LABEL + labelId);}
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -70,7 +70,7 @@
             return jdbcTemplate.queryForList(sql.toString(), params.toArray());
         }
 
-        public int countIssuesByOpenStatus(boolean isOpen) {
+        public Integer countIssuesByOpenStatus(boolean isOpen) {
             return jdbcTemplate.queryForObject(
                     "SELECT COUNT(*) FROM issue WHERE is_open = ?",
                     Integer.class,

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -41,6 +41,7 @@
                 LEFT JOIN issue_assignee ia ON i.issue_id = ia.issue_id
                 LEFT JOIN `user` a ON ia.assignee_id = a.user_id
                 WHERE i.is_open = ?
+                ORDER BY i.created_at DESC
             """);
 
             List<Object> params = new ArrayList<>();

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -19,8 +19,8 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.searchIssueDetailDto;
 import codesquad.team4.issuetracker.label.IssueLabelRepository;
 import codesquad.team4.issuetracker.label.LabelDao;
-import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.MilestoneRepository;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import codesquad.team4.issuetracker.user.AssigneeDao;
@@ -65,7 +65,7 @@ public class IssueService {
 
         Map<Long, IssueResponseDto.IssueInfo> issueMap = new LinkedHashMap<>();
         Map<Long, Set<UserInfo>> assigneeMap = new HashMap<>();
-        Map<Long, Set<LabelDto.LabelInfo>> labelMap = new HashMap<>();
+        Map<Long, Set<LabelResponseDto.LabelInfo>> labelMap = new HashMap<>();
 
         for (Map<String, Object> row : rows) {
             Long issueId = (Long) row.get("issue_id");

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -22,7 +22,7 @@ import codesquad.team4.issuetracker.label.LabelDao;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.MilestoneRepository;
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import codesquad.team4.issuetracker.user.AssigneeDao;
 import codesquad.team4.issuetracker.user.IssueAssigneeRepository;
 import codesquad.team4.issuetracker.user.UserDao;
@@ -112,7 +112,7 @@ public class IssueService {
                                 .build())
                         .assignees(assigneeMap.getOrDefault(issueId, Set.of()))
                         .labels(labelMap.getOrDefault(issueId, Set.of()))
-                        .milestone(MilestoneDto.MilestoneInfo.builder()
+                        .milestone(MilestoneResponseDto.MilestoneInfo.builder()
                                 .id((Long) row.get("milestone_id"))
                                 .title((String) row.get("milestone_title"))
                                 .build())

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -2,7 +2,7 @@ package codesquad.team4.issuetracker.issue.dto;
 
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,7 +33,7 @@ public class IssueResponseDto {
         private UserDto.UserInfo author;
         private Set<LabelInfo> labels;
         private Set<UserDto.UserInfo> assignees;
-        private MilestoneDto.MilestoneInfo milestone;
+        private MilestoneResponseDto.MilestoneInfo milestone;
         private String createdAt;
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -1,7 +1,7 @@
 package codesquad.team4.issuetracker.issue.dto;
 
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -1,12 +1,13 @@
 package codesquad.team4.issuetracker.label;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelFilter;
+import codesquad.team4.issuetracker.label.dto.LabelRequestDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelFilter;
 import codesquad.team4.issuetracker.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,8 +17,14 @@ public class LabelController {
 
     @GetMapping("/filter")
     public ApiResponse<LabelFilter> getFilterLabels() {
-        LabelDto.LabelFilter result = labelService.getFilterLabels();
+        LabelResponseDto.LabelFilter result = labelService.getFilterLabels();
         return ApiResponse.success(result);
+    }
+
+    @PostMapping(value = "")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createLabel(@RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
+        labelService.createLabel(request);
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -21,10 +21,24 @@ public class LabelController {
         return ApiResponse.success(result);
     }
 
-    @PostMapping(value = "")
+    @PostMapping( "")
     @ResponseStatus(HttpStatus.CREATED)
     public void createLabel(@RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
         labelService.createLabel(request);
+    }
+
+    @PutMapping("/{label-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateLabel(
+        @PathVariable("label-id") Long labelId,
+        @RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
+        labelService.updateLabel(labelId, request);
+    }
+
+    @DeleteMapping("/{label-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteLabel(@PathVariable("label-id") Long labelId) {
+        labelService.deleteLabel(labelId);
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelController.java
@@ -21,6 +21,12 @@ public class LabelController {
         return ApiResponse.success(result);
     }
 
+    @GetMapping("")
+    public ApiResponse<LabelResponseDto.LabelListDto> showLableList() {
+         LabelResponseDto.LabelListDto labels = labelService.getAllLabels();
+         return ApiResponse.success(labels);
+    }
+
     @PostMapping( "")
     @ResponseStatus(HttpStatus.CREATED)
     public void createLabel(@RequestBody @Valid LabelRequestDto.CreateLabelDto request) {
@@ -40,5 +46,4 @@ public class LabelController {
     public void deleteLabel(@PathVariable("label-id") Long labelId) {
         labelService.deleteLabel(labelId);
     }
-
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
@@ -40,4 +40,19 @@ public class LabelDao {
 
         return namedParameterJdbcTemplate.queryForList(sql, params, Long.class);
     }
+
+    public List<LabelResponseDto.LabelDto> findAllLabels() {
+        String sql = """
+        SELECT label_id, name, description, color
+        FROM label
+    """;
+        return jdbcTemplate.query(sql, (rs, rowNum) ->
+            LabelResponseDto.LabelDto.builder()
+                .id(rs.getLong("label_id"))
+                .name(rs.getString("name"))
+                .description(rs.getString("description"))
+                .color(rs.getString("color"))
+                .build()
+        );
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.label;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -16,11 +16,11 @@ public class LabelDao {
     private final JdbcTemplate jdbcTemplate;
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
-    public List<LabelDto.LabelInfo> findLabelForFiltering() {
+    public List<LabelResponseDto.LabelInfo> findLabelForFiltering() {
         String sql = "SELECT label_id, name, color FROM label";
 
         return jdbcTemplate.query(sql, (rs, rowNum) ->
-                LabelDto.LabelInfo.builder()
+                LabelResponseDto.LabelInfo.builder()
                         .id(rs.getLong("label_id"))
                         .name(rs.getString("name"))
                         .color(rs.getString("color"))

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelDao.java
@@ -45,6 +45,7 @@ public class LabelDao {
         String sql = """
         SELECT label_id, name, description, color
         FROM label
+        ORDER BY created_at DESC
     """;
         return jdbcTemplate.query(sql, (rs, rowNum) ->
             LabelResponseDto.LabelDto.builder()

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelRepository.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.label;
+
+import codesquad.team4.issuetracker.entity.Label;
+import org.springframework.data.repository.CrudRepository;
+
+public interface LabelRepository extends CrudRepository<Label, Long> {
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -1,26 +1,43 @@
 package codesquad.team4.issuetracker.label;
 
+import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
+import codesquad.team4.issuetracker.entity.Label;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto;
-import codesquad.team4.issuetracker.label.dto.LabelDto.LabelInfo;
+import codesquad.team4.issuetracker.label.dto.LabelRequestDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class LabelService {
+    private static final String CREATE_LABEL = "레이블이 생성되었습니다";
 
     private final LabelDao labelDao;
+    private final LabelRepository labelRepository;
 
-    public LabelDto.LabelFilter getFilterLabels() {
-        List<LabelDto.LabelInfo> labels = labelDao.findLabelForFiltering();
+    public LabelResponseDto.LabelFilter getFilterLabels() {
+        List<LabelResponseDto.LabelInfo> labels = labelDao.findLabelForFiltering();
 
-        return LabelDto.LabelFilter.builder()
+        return LabelResponseDto.LabelFilter.builder()
                 .labels(labels)
                 .count(labels.size())
                 .build();
     }
+
+    @Transactional
+    public void createLabel(LabelRequestDto.CreateLabelDto request) {
+        Label label = Label.builder()
+            .name(request.getName())
+            .description(request.getDescription())
+            .color(request.getColor())
+            .build();
+
+        labelRepository.save(label);
+    }
+
+
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -51,8 +51,9 @@ public class LabelService {
 
     @Transactional
     public void updateLabel(Long labelId, LabelRequestDto.CreateLabelDto request) {
-        labelRepository.findById(labelId)
-            .orElseThrow(() -> new LabelNotFoundException(labelId));
+        if (!labelRepository.existsById(labelId)) {
+            throw new LabelNotFoundException(labelId);
+        }
 
         Label updatedLabel = Label.builder()
             .id(labelId)

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -30,6 +30,14 @@ public class LabelService {
                 .build();
     }
 
+    public LabelResponseDto.LabelListDto getAllLabels() {
+        List<LabelResponseDto.LabelDto> labels = labelDao.findAllLabels();
+        return LabelResponseDto.LabelListDto.builder()
+            .labels(labels)
+            .build();
+
+    }
+
     @Transactional
     public void createLabel(LabelRequestDto.CreateLabelDto request) {
         Label label = Label.builder()

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -69,5 +69,6 @@ public class LabelService {
         if (!labelRepository.existsById(labelId)) {
             throw new LabelNotFoundException(labelId);
         }
+        labelRepository.deleteById(labelId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/LabelService.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.label;
 
 import codesquad.team4.issuetracker.comment.dto.CommentRequestDto;
 import codesquad.team4.issuetracker.entity.Label;
+import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.label.dto.LabelRequestDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +41,25 @@ public class LabelService {
         labelRepository.save(label);
     }
 
+    @Transactional
+    public void updateLabel(Long labelId, LabelRequestDto.CreateLabelDto request) {
+        labelRepository.findById(labelId)
+            .orElseThrow(() -> new LabelNotFoundException(labelId));
 
+        Label updatedLabel = Label.builder()
+            .id(labelId)
+            .name(request.getName())
+            .description(request.getDescription())
+            .color(request.getColor())
+            .build();
+
+        labelRepository.save(updatedLabel);
+    }
+
+    @Transactional
+    public void deleteLabel(Long labelId) {
+        if (!labelRepository.existsById(labelId)) {
+            throw new LabelNotFoundException(labelId);
+        }
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelRequestDto.java
@@ -1,0 +1,19 @@
+package codesquad.team4.issuetracker.label.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class LabelRequestDto {
+    @AllArgsConstructor
+    @Builder
+    @Getter
+    public static class CreateLabelDto {
+        @NotBlank
+        private String name;
+        private String description;
+        @NotBlank
+        private String color;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
@@ -1,6 +1,5 @@
 package codesquad.team4.issuetracker.label.dto;
 
-import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -8,7 +7,7 @@ import lombok.Getter;
 
 import java.util.List;
 
-public class LabelDto {
+public class LabelResponseDto {
 
     @AllArgsConstructor
     @Getter
@@ -27,4 +26,5 @@ public class LabelDto {
         private List<LabelInfo> labels;
         private int count;
     }
+
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
@@ -1,11 +1,14 @@
 package codesquad.team4.issuetracker.label.dto;
 
+import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
+import codesquad.team4.issuetracker.user.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Set;
 
 public class LabelResponseDto {
 
@@ -25,6 +28,23 @@ public class LabelResponseDto {
     public static class LabelFilter {
         private List<LabelInfo> labels;
         private int count;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class LabelListDto {
+        private List<LabelDto> labels;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class LabelDto {
+        private Long id;
+        private String name;
+        private String description;
+        private String color;
     }
 
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/label/dto/LabelResponseDto.java
@@ -1,14 +1,11 @@
 package codesquad.team4.issuetracker.label.dto;
 
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
-import codesquad.team4.issuetracker.user.dto.UserDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.List;
-import java.util.Set;
 
 public class LabelResponseDto {
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
@@ -6,6 +6,7 @@ import codesquad.team4.issuetracker.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,4 +27,9 @@ public class MilestoneController {
         return ApiResponse.success(result);
     }
 
+    @GetMapping("")
+    public ApiResponse<MilestoneResponseDto.MilestoneListDto> getMilestones(@RequestParam boolean isOpen) {
+        MilestoneResponseDto.MilestoneListDto result = milestoneService.getMilestones(isOpen);
+        return ApiResponse.success(result);
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
@@ -1,13 +1,13 @@
 package codesquad.team4.issuetracker.milestone;
 
+import codesquad.team4.issuetracker.milestone.dto.MilestoneRequestDto;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto.MilestoneFilter;
 import codesquad.team4.issuetracker.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,4 +32,25 @@ public class MilestoneController {
         MilestoneResponseDto.MilestoneListDto result = milestoneService.getMilestones(isOpen);
         return ApiResponse.success(result);
     }
+
+    @PostMapping("")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createMilestone(@RequestBody @Valid MilestoneRequestDto.CreateMilestoneDto request) {
+        milestoneService.createMilestone(request);
+    }
+
+    @PutMapping("/{milestone-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateMilestone(
+        @PathVariable("milestone-id") Long milestoneId,
+        @RequestBody @Valid MilestoneRequestDto.CreateMilestoneDto request) {
+        milestoneService.updateMilestone(milestoneId, request);
+    }
+
+    @DeleteMapping("/{milestone-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleted(@PathVariable("milestone-id") Long milestoneId) {
+        milestoneService.deleteMilestone(milestoneId);
+    }
+
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
@@ -49,8 +49,13 @@ public class MilestoneController {
 
     @DeleteMapping("/{milestone-id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleted(@PathVariable("milestone-id") Long milestoneId) {
+    public void deleteMilestone(@PathVariable("milestone-id") Long milestoneId) {
         milestoneService.deleteMilestone(milestoneId);
     }
 
+    @PatchMapping("/{milestone-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void closeMilestone(@PathVariable("milestone-id") Long milestoneId) {
+        milestoneService.closeMilestone(milestoneId);
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneController.java
@@ -1,7 +1,7 @@
 package codesquad.team4.issuetracker.milestone;
 
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto.MilestoneFilter;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto.MilestoneFilter;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -16,7 +16,13 @@ public class MilestoneController {
 
     @GetMapping("/filter")
     public ApiResponse<MilestoneFilter> getFilterMilestones() {
-        MilestoneDto.MilestoneFilter result = milestoneService.getFilterMilestones();
+        MilestoneResponseDto.MilestoneFilter result = milestoneService.getFilterMilestones();
+        return ApiResponse.success(result);
+    }
+
+    @GetMapping("/count")
+    public ApiResponse<MilestoneResponseDto.MilestoneCountDto> showMilestoneCount() {
+        MilestoneResponseDto.MilestoneCountDto result = milestoneService.getMilestoneCount();
         return ApiResponse.success(result);
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneDao.java
@@ -2,6 +2,7 @@ package codesquad.team4.issuetracker.milestone;
 
 import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -29,5 +30,22 @@ public class MilestoneDao {
             Integer.class,
             isOpen
         );
+    }
+
+    public List<Map<String, Object>> findMilestonesByOpenStatus(boolean isOpen) {
+        StringBuilder sql = new StringBuilder("""
+            SELECT m.milestone_id AS id,
+            m.name,
+            m.description,
+            m.end_date,
+            COUNT(CASE WHEN i.is_open = true THEN 1 END) AS open_issue_count,
+            COUNT(CASE WHEN i.is_open = false THEN 1 END) AS closed_issue_count
+            FROM milestone m
+            LEFT JOIN issue i ON m.milestone_id = i.milestone_id
+            WHERE m.is_open = ?
+            GROUP BY m.milestone_id
+            ORDER BY m.created_at DESC
+            """);
+        return jdbcTemplate.queryForList(sql.toString(), isOpen);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneDao.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.milestone;
 
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -12,14 +12,22 @@ public class MilestoneDao {
 
     private final JdbcTemplate jdbcTemplate;
 
-    public List<MilestoneDto.MilestoneInfo> findMilestoneForFiltering() {
+    public List<MilestoneResponseDto.MilestoneInfo> findMilestoneForFiltering() {
         String sql = "SELECT milestone_id, name FROM milestone";
 
        return jdbcTemplate.query(sql, (rs, rowNum) ->
-                MilestoneDto.MilestoneInfo.builder()
+                MilestoneResponseDto.MilestoneInfo.builder()
                         .id(rs.getLong("milestone_id"))
                         .title(rs.getString("name"))
                         .build()
+        );
+    }
+
+    public Integer countMilestonesByOpenStatus(boolean isOpen) {
+        return jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM milestone WHERE is_open = ?",
+            Integer.class,
+            isOpen
         );
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
@@ -5,7 +5,10 @@ import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto.Milestone
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.sql.Date;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +31,40 @@ public class MilestoneService {
         return MilestoneResponseDto.MilestoneCountDto.builder()
             .openCount(openCount != null ? openCount : 0)
             .closedCount(closedCount != null ? closedCount : 0)
+            .build();
+    }
+
+    public MilestoneResponseDto.MilestoneListDto getMilestones(boolean isOpen) {
+        List<Map<String, Object>> rows = milestoneDao.findMilestonesByOpenStatus(isOpen);
+
+        List<MilestoneResponseDto.MilestoneDto> result = new ArrayList<>();
+
+        for (Map<String, Object> row :  rows) {
+            int open = ((Number) row.get("open_issue_count")).intValue();
+            int closed = ((Number) row.get("closed_issue_count")).intValue();
+
+            double progress = 0.0;
+            if (open+closed > 0) {
+                double raw = closed * 100.0 / (open + closed);
+                progress = Math.round(raw * 10.0) / 10.0; //소수점 1자리 반올림
+            }
+
+            MilestoneResponseDto.MilestoneDto dto = MilestoneResponseDto.MilestoneDto.builder()
+                .id((Long) row.get("id"))
+                .name((String) row.get("name"))
+                .description((String) row.get("description"))
+                .endDate(row.get("end_date") != null
+                    ? ((Date) row.get("end_date")).toLocalDate()
+                    : null)
+                .progress(progress)
+                .openIssues(open)
+                .closedIssues(closed)
+                .build();
+
+            result.add(dto);
+        }
+        return MilestoneResponseDto.MilestoneListDto.builder()
+            .milestones(result)
             .build();
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
@@ -1,7 +1,7 @@
 package codesquad.team4.issuetracker.milestone;
 
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto.MilestoneInfo;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto.MilestoneInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,12 +12,22 @@ import java.util.List;
 public class MilestoneService {
     private final MilestoneDao milestoneDao;
 
-    public MilestoneDto.MilestoneFilter getFilterMilestones() {
+    public MilestoneResponseDto.MilestoneFilter getFilterMilestones() {
         List<MilestoneInfo> milestones = milestoneDao.findMilestoneForFiltering();
 
-        return MilestoneDto.MilestoneFilter.builder()
+        return MilestoneResponseDto.MilestoneFilter.builder()
                 .milestones(milestones)
                 .count(milestones.size())
                 .build();
+    }
+
+    public MilestoneResponseDto.MilestoneCountDto getMilestoneCount() {
+        Integer openCount = milestoneDao.countMilestonesByOpenStatus(true);
+        Integer closedCount = milestoneDao.countMilestonesByOpenStatus(false);
+
+        return MilestoneResponseDto.MilestoneCountDto.builder()
+            .openCount(openCount != null ? openCount : 0)
+            .closedCount(closedCount != null ? closedCount : 0)
+            .build();
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
@@ -1,9 +1,14 @@
 package codesquad.team4.issuetracker.milestone;
 
+import codesquad.team4.issuetracker.entity.Milestone;
+import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
+import codesquad.team4.issuetracker.label.LabelRepository;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneRequestDto;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto.MilestoneInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Date;
 import java.util.ArrayList;
@@ -14,6 +19,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class MilestoneService {
     private final MilestoneDao milestoneDao;
+    private final MilestoneRepository milestoneRepository;
+    private final LabelRepository labelRepository;
 
     public MilestoneResponseDto.MilestoneFilter getFilterMilestones() {
         List<MilestoneInfo> milestones = milestoneDao.findMilestoneForFiltering();
@@ -66,5 +73,39 @@ public class MilestoneService {
         return MilestoneResponseDto.MilestoneListDto.builder()
             .milestones(result)
             .build();
+    }
+
+    @Transactional
+    public void createMilestone(MilestoneRequestDto.CreateMilestoneDto request) {
+        Milestone milestone = Milestone.builder()
+            .name(request.getName())
+            .description(request.getDescription())
+            .endDate(request.getEndDate())
+            .build();
+
+        milestoneRepository.save(milestone);
+    }
+
+    @Transactional
+    public void updateMilestone(Long milestoneId, MilestoneRequestDto.CreateMilestoneDto request) {
+        milestoneRepository.findById(milestoneId)
+            .orElseThrow(() -> new MilestoneNotFoundException(milestoneId));
+
+        Milestone updatedMilestone = Milestone.builder()
+            .id(milestoneId)
+            .name(request.getName())
+            .description(request.getDescription())
+            .endDate(request.getEndDate())
+            .build();
+
+        milestoneRepository.save(updatedMilestone);
+    }
+
+    @Transactional
+    public void deleteMilestone(Long milestoneId) {
+        if (!milestoneRepository.existsById(milestoneId)) {
+            throw new MilestoneNotFoundException(milestoneId);
+        }
+        milestoneRepository.deleteById(milestoneId);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneService.java
@@ -1,6 +1,7 @@
 package codesquad.team4.issuetracker.milestone;
 
 import codesquad.team4.issuetracker.entity.Milestone;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidCommentAccessException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
 import codesquad.team4.issuetracker.label.LabelRepository;
 import codesquad.team4.issuetracker.milestone.dto.MilestoneRequestDto;
@@ -88,8 +89,9 @@ public class MilestoneService {
 
     @Transactional
     public void updateMilestone(Long milestoneId, MilestoneRequestDto.CreateMilestoneDto request) {
-        milestoneRepository.findById(milestoneId)
-            .orElseThrow(() -> new MilestoneNotFoundException(milestoneId));
+        if (!milestoneRepository.existsById(milestoneId)) {
+            throw new MilestoneNotFoundException(milestoneId);
+        }
 
         Milestone updatedMilestone = Milestone.builder()
             .id(milestoneId)
@@ -107,5 +109,15 @@ public class MilestoneService {
             throw new MilestoneNotFoundException(milestoneId);
         }
         milestoneRepository.deleteById(milestoneId);
+    }
+
+    @Transactional
+    public void closeMilestone(Long milestoneId) {
+        Milestone milestone = milestoneRepository.findById(milestoneId)
+            .orElseThrow(() -> new MilestoneNotFoundException(milestoneId));
+
+        milestone.updateStatus(false);
+
+        milestoneRepository.save(milestone);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneRequestDto.java
@@ -1,0 +1,4 @@
+package codesquad.team4.issuetracker.milestone.dto;
+
+public class MilestoneRequestDto {
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneRequestDto.java
@@ -1,4 +1,20 @@
 package codesquad.team4.issuetracker.milestone.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
 public class MilestoneRequestDto {
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class CreateMilestoneDto {
+        @NotBlank
+        private String name;
+        private String description;
+        private LocalDate endDate;
+    }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneResponseDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 import java.util.List;
 
-public class MilestoneDto {
+public class MilestoneResponseDto {
 
     @AllArgsConstructor
     @Getter
@@ -22,5 +22,13 @@ public class MilestoneDto {
     public static class MilestoneFilter {
         private List<MilestoneInfo> milestones;
         private int count;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class MilestoneCountDto {
+        private Integer openCount;
+        private Integer closedCount;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/dto/MilestoneResponseDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class MilestoneResponseDto {
@@ -30,5 +31,25 @@ public class MilestoneResponseDto {
     public static class MilestoneCountDto {
         private Integer openCount;
         private Integer closedCount;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class MilestoneDto {
+        private Long id;
+        private String name;
+        private String description;
+        private LocalDate endDate;
+        private double progress;
+        private int openIssues;
+        private int closedIssues;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class MilestoneListDto {
+        private List<MilestoneDto> milestones;
     }
 }

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -14,7 +14,7 @@ CREATE TABLE milestone (
                            name VARCHAR(50) NOT NULL UNIQUE,
                            description VARCHAR(50),
                            end_date DATE,
-                           is_open BOOLEAN,
+                           is_open BOOLEAN DEFAULT true,
                            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/backend/src/test/java/codesquad/team4/issuetracker/label/LabelServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/label/LabelServiceTest.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.label;
 
-import codesquad.team4.issuetracker.label.dto.LabelDto;
+import codesquad.team4.issuetracker.label.dto.LabelResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +29,7 @@ public class LabelServiceTest {
     void setUp() {
         jdbcTemplate.update("""
             INSERT INTO label (label_id, name, color, description, created_at, updated_at)
-            VALUES 
+            VALUES
                 (1, 'bug', 'qww11', '버그 버그', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
                 (2, 'refactor', 'qq2q11', '리팩터링', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
         """);
@@ -39,7 +39,7 @@ public class LabelServiceTest {
     @DisplayName("레이블 필터링 정보 조회")
     void 레이블_필터링_정보_조회() {
         // when
-        LabelDto.LabelFilter result = labelService.getFilterLabels();
+        LabelResponseDto.LabelFilter result = labelService.getFilterLabels();
 
         // then
         assertThat(result.getLabels()).hasSize(2);

--- a/backend/src/test/java/codesquad/team4/issuetracker/milestone/MilestoneServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/milestone/MilestoneServiceTest.java
@@ -1,6 +1,6 @@
 package codesquad.team4.issuetracker.milestone;
 
-import codesquad.team4.issuetracker.milestone.dto.MilestoneDto;
+import codesquad.team4.issuetracker.milestone.dto.MilestoneResponseDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,7 +36,7 @@ public class MilestoneServiceTest {
     @DisplayName("마일스톤 필터링 정보 조회")
     void 마일스톤_필터링_정보_조회() {
         // when
-        MilestoneDto.MilestoneFilter result = milestoneService.getFilterMilestones();
+        MilestoneResponseDto.MilestoneFilter result = milestoneService.getFilterMilestones();
 
         // then
         assertThat(result.getMilestones()).hasSize(2);

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -14,7 +14,7 @@ CREATE TABLE milestone (
                            name VARCHAR(50) NOT NULL UNIQUE,
                            description VARCHAR(50),
                            end_date DATE,
-                           is_open BOOLEAN,
+                           is_open BOOLEAN DEFAULT true,
                            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
🔥 작업 내용 요약
* 레이블/마일스톤 목록 조회, 생성, 수정, 삭
* 마일스톤 열린/닫힌 개수 조회
* 마일스톤 닫기

✅ 작업 범위
* 레이블 목록 조회, 생성, 수정, 삭제 API 구현
* 마일스톤 목록 조회, 생성, 수정, 삭제 API 구현
* 마일스톤 열린.닫힌 개수 조회 API 구현
* 마일스톤 닫기 API 구현
* 목록을 가져올 때 최신순으로 정렬 (ORDER BY created_at DESC) - 이슈, 댓글, 레이블, 마일스톤

🚧 고려사항
마일스톤을 생성하면 is_open=true로 스키마 수정.
