### PR TITLE
[Feat] Jwt 로그인 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,7 +30,13 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    //bcrypt
     implementation 'org.mindrot:jbcrypt:0.4'
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.mindrot:jbcrypt:0.4'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
@@ -1,9 +1,16 @@
 package codesquad.team4.issuetracker.auth;
 
 import codesquad.team4.issuetracker.auth.dto.AuthRequestDto;
+import codesquad.team4.issuetracker.auth.dto.AuthResponseDto;
+import codesquad.team4.issuetracker.auth.dto.AuthResponseDto.LoginResponseDto;
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.response.ApiResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,10 +23,38 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public void signup(@RequestBody @Valid AuthRequestDto.SignupRequestDto request) {
         authService.createNewUser(request);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<AuthResponseDto.LoginResponseDto> login(
+        @RequestBody @Valid AuthRequestDto.LoginRequestDto requestDto,  HttpServletResponse response) {
+
+        User user = authService.checkEmailAndPassword(requestDto);
+
+        String token = jwtProvider.createToken(user.getId());
+
+        ResponseCookie cookie = ResponseCookie.from("jwt", token)
+            .httpOnly(true)
+            .path("/")
+            .maxAge(60 * 60 * 24) // 1일
+            .build();
+
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ApiResponse.success(createLoginUser(user));
+    }
+
+    private LoginResponseDto createLoginUser(User user) {
+        return LoginResponseDto.builder()
+            .userId(user.getId())
+            .nickname(user.getNickname())
+            .profileImage(user.getProfileImage())
+            .build();
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
@@ -1,0 +1,26 @@
+package codesquad.team4.issuetracker.auth;
+
+import codesquad.team4.issuetracker.auth.dto.AuthRequestDto;
+import codesquad.team4.issuetracker.auth.dto.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void signup(@RequestBody @Valid AuthRequestDto.SignupRequestDto request) {
+        authService.createNewUser(request);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
@@ -41,6 +41,7 @@ public class AuthController {
 
         ResponseCookie cookie = ResponseCookie.from("jwt", token)
             .httpOnly(true)
+            .sameSite("Strict")
             .path("/")
             .maxAge(60 * 60 * 24) // 1일
             .build();

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
@@ -5,6 +5,7 @@ import codesquad.team4.issuetracker.auth.dto.AuthResponseDto;
 import codesquad.team4.issuetracker.auth.dto.AuthResponseDto.LoginResponseDto;
 import codesquad.team4.issuetracker.entity.User;
 import codesquad.team4.issuetracker.response.ApiResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +40,7 @@ public class AuthController {
 
         String token = jwtProvider.createToken(user.getId());
 
-        ResponseCookie cookie = ResponseCookie.from("jwt", token)
+        ResponseCookie cookie = ResponseCookie.from("access_token", token)
             .httpOnly(true)
             .sameSite("Strict")
             .path("/")
@@ -57,5 +58,15 @@ public class AuthController {
             .nickname(user.getNickname())
             .profileImage(user.getProfileImage())
             .build();
+    }
+
+    @PostMapping("/logout")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void logout(HttpServletResponse response) {
+        Cookie cookie = new Cookie("access_token", null);
+        cookie.setMaxAge(0); // 즉시 만료
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthController.java
@@ -1,7 +1,6 @@
 package codesquad.team4.issuetracker.auth;
 
 import codesquad.team4.issuetracker.auth.dto.AuthRequestDto;
-import codesquad.team4.issuetracker.auth.dto.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthInterceptor.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthInterceptor.java
@@ -1,0 +1,63 @@
+package codesquad.team4.issuetracker.auth;
+
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.user.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+@Slf4j
+public class AuthInterceptor implements HandlerInterceptor {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public static final String USER_ATTRIBUTE = "authenticatedUser";
+    private static final String NEED_LOGIN = "로그인이 필요합니다.";
+    private static final String NOT_FOUND_USER = "사용자를 찾을 수 없습니다.";
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        Optional<String> token = extractTokenFromCookies(request.getCookies());
+        if (token.isEmpty() || !jwtProvider.isValid(token.get())) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, NEED_LOGIN);
+            return false;
+        }
+
+        return authenticateRequest(request, response, token.get());
+    }
+
+    private Optional<String> extractTokenFromCookies(Cookie[] cookies) {
+        if (cookies == null) return Optional.empty();
+
+        for (Cookie cookie : cookies) {
+            if ("jwt".equals(cookie.getName())) {
+                return Optional.of(cookie.getValue());
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean authenticateRequest(HttpServletRequest request, HttpServletResponse response, String token)
+        throws IOException {
+        Long userId = jwtProvider.getUserId(token);
+        Optional<User> optionalUser = userRepository.findById(userId);
+
+        if (optionalUser.isEmpty()) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, NOT_FOUND_USER);
+            return false;
+        }
+
+        request.setAttribute(USER_ATTRIBUTE, optionalUser.get());
+        return true;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthInterceptor.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthInterceptor.java
@@ -40,7 +40,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         if (cookies == null) return Optional.empty();
 
         for (Cookie cookie : cookies) {
-            if ("jwt".equals(cookie.getName())) {
+            if ("access_token".equals(cookie.getName())) {
                 return Optional.of(cookie.getValue());
             }
         }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
@@ -6,10 +6,10 @@ import static codesquad.team4.issuetracker.exception.ExceptionMessage.NICKNAME_A
 import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.LoginRequestDto;
 import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
 import codesquad.team4.issuetracker.entity.User;
-import codesquad.team4.issuetracker.exception.badrequest.PasswordNotEqualException;
+import codesquad.team4.issuetracker.exception.unauthorized.PasswordNotEqualException;
 import codesquad.team4.issuetracker.exception.conflict.EmailAlreadyExistException;
 import codesquad.team4.issuetracker.exception.conflict.NicknameAlreadyExistException;
-import codesquad.team4.issuetracker.exception.notfound.UserByEmailNotFoundException;
+import codesquad.team4.issuetracker.exception.unauthorized.UserByEmailNotFoundException;
 import codesquad.team4.issuetracker.user.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
@@ -3,10 +3,13 @@ package codesquad.team4.issuetracker.auth;
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.EMAIL_ALREADY_EXIST;
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.NICKNAME_ALREADY_EXIST;
 
+import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.LoginRequestDto;
 import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
 import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.badrequest.PasswordNotEqualException;
 import codesquad.team4.issuetracker.exception.conflict.EmailAlreadyExistException;
 import codesquad.team4.issuetracker.exception.conflict.NicknameAlreadyExistException;
+import codesquad.team4.issuetracker.exception.notfound.UserByEmailNotFoundException;
 import codesquad.team4.issuetracker.user.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -54,5 +57,16 @@ public class AuthService {
                 throw new NicknameAlreadyExistException(NICKNAME_ALREADY_EXIST);
             }
         }
+    }
+
+    public User checkEmailAndPassword(LoginRequestDto request) {
+        User user = userRepository.findByEmail(request.getEmail())
+            .orElseThrow(UserByEmailNotFoundException::new);
+
+        if (!BCrypt.checkpw(request.getPassword(), user.getPassword())) {
+            throw new PasswordNotEqualException();
+        }
+
+        return user;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
@@ -1,4 +1,4 @@
-package codesquad.team4.issuetracker.auth.dto;
+package codesquad.team4.issuetracker.auth;
 
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.EMAIL_ALREADY_EXIST;
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.NICKNAME_ALREADY_EXIST;
@@ -25,8 +25,8 @@ public class AuthService {
 
         //패스워드 해싱
         String hashPassword = BCrypt.hashpw(request.getPassword(), BCrypt.gensalt());
-        //DB에 저장
 
+        //DB에 저장
         User user = User.builder()
             .email(request.getEmail())
             .nickname(request.getNickname())

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/AuthService.java
@@ -12,11 +12,14 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+    @Value("${profile.default-image-url}")
+    private String DEFAULT_PROFILE_URL;
 
     private final UserRepository userRepository;
     public void createNewUser(SignupRequestDto request) {
@@ -31,8 +34,9 @@ public class AuthService {
             .email(request.getEmail())
             .nickname(request.getNickname())
             .password(hashPassword)
+            .profileImage(DEFAULT_PROFILE_URL)
             .createdAt(LocalDateTime.now())
-            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
             .build();
 
         userRepository.save(user);

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/JwtProvider.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/JwtProvider.java
@@ -1,0 +1,48 @@
+package codesquad.team4.issuetracker.auth;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+    private final long expiration = 1000 * 60 * 30; //30분
+
+    public String createToken(Long userId) {
+        Date now = new Date();
+        return Jwts.builder()
+            .setSubject(String.valueOf(userId))
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + expiration))
+            .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    public Long getUserId(String token) {
+        return Long.valueOf(Jwts.parserBuilder()
+            .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes()))
+            .build()
+            .parseClaimsJws(token)
+            .getBody()
+            .getSubject());
+    }
+
+    public boolean isValid(String token) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes()))
+                .build()
+                .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthRequestDto.java
@@ -1,0 +1,21 @@
+package codesquad.team4.issuetracker.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthRequestDto {
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class SignupRequestDto{
+        @NotNull
+        private String email;
+        @NotNull
+        private String password;
+        @NotNull
+        private String nickname;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthRequestDto.java
@@ -1,5 +1,6 @@
 package codesquad.team4.issuetracker.auth.dto;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,10 +13,22 @@ public class AuthRequestDto {
     @Builder
     public static class SignupRequestDto{
         @NotNull
+        @Email
         private String email;
         @NotNull
         private String password;
         @NotNull
         private String nickname;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class LoginRequestDto{
+        @NotNull
+        @Email
+        private String email;
+        @NotNull
+        private String password;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthResponseDto.java
@@ -1,0 +1,16 @@
+package codesquad.team4.issuetracker.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthResponseDto {
+    @AllArgsConstructor
+    @Getter
+    @Builder
+    public static class LoginResponseDto{
+        private Long userId;
+        private String nickname;
+        private String profileImage;
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/dto/AuthService.java
@@ -1,0 +1,54 @@
+package codesquad.team4.issuetracker.auth.dto;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.EMAIL_ALREADY_EXIST;
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NICKNAME_ALREADY_EXIST;
+
+import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.conflict.EmailAlreadyExistException;
+import codesquad.team4.issuetracker.exception.conflict.NicknameAlreadyExistException;
+import codesquad.team4.issuetracker.user.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    public void createNewUser(SignupRequestDto request) {
+        //이메일, 닉네임 중복 확인
+        validateDuplicateEmailOrNickname(request);
+
+        //패스워드 해싱
+        String hashPassword = BCrypt.hashpw(request.getPassword(), BCrypt.gensalt());
+        //DB에 저장
+
+        User user = User.builder()
+            .email(request.getEmail())
+            .nickname(request.getNickname())
+            .password(hashPassword)
+            .createdAt(LocalDateTime.now())
+            .createdAt(LocalDateTime.now())
+            .build();
+
+        userRepository.save(user);
+    }
+
+    private void validateDuplicateEmailOrNickname(SignupRequestDto request) {
+        Optional<User> duplicate = userRepository.findByEmailOrNickname(request.getEmail(), request.getNickname());
+
+        if (duplicate.isPresent()) {
+            User user = duplicate.get();
+            if (user.getEmail().equals(request.getEmail())) {
+                throw new EmailAlreadyExistException(EMAIL_ALREADY_EXIST);
+            }
+            if (user.getNickname().equals(request.getNickname())) {
+                throw new NicknameAlreadyExistException(NICKNAME_ALREADY_EXIST);
+            }
+        }
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
@@ -1,11 +1,18 @@
 package codesquad.team4.issuetracker.config;
 
+import codesquad.team4.issuetracker.auth.AuthInterceptor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Autowired
+    private AuthInterceptor authInterceptor;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
@@ -15,5 +22,12 @@ public class WebConfig implements WebMvcConfigurer {
                 )
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowCredentials(true);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+            .addPathPatterns("/api/**")
+            .excludePathPatterns("/api/auth/**");
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/CountDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/CountDao.java
@@ -9,72 +9,32 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class CountDao {
-
     private final JdbcTemplate jdbcTemplate;
 
-    public IssueCountDto getIssueCounts() {
-        var sql = """
-            SELECT issue_open_count, issue_closed_count
-              FROM summary_count
-             WHERE id = 1
-        """;
-        return jdbcTemplate.queryForObject(sql, (rs, rn) ->
-            IssueCountDto.builder()
-                .openCount  (rs.getInt("issue_open_count"))
-                .closedCount(rs.getInt("issue_closed_count"))
-                .build()
+    public static final String ISSUE_OPEN        = "issue_open";
+    public static final String ISSUE_CLOSED      = "issue_closed";
+    public static final String MILESTONE_OPEN    = "milestone_open";
+    public static final String MILESTONE_CLOSED  = "milestone_closed";
+
+    public int getCount(String type) {
+        return jdbcTemplate.queryForObject(
+                "SELECT count FROM summary_count WHERE type = ?",
+                Integer.class, type
         );
     }
 
-    public MilestoneCountDto getMilestoneCount() {
-        var sql = """
-            SELECT milestone_open_count, milestone_closed_count
-              FROM summary_count
-             WHERE id = 1
-        """;
-        return jdbcTemplate.queryForObject(sql, (rs, rn) ->
-            MilestoneCountDto.builder()
-                .openCount  (rs.getInt("milestone_open_count"))
-                .closedCount(rs.getInt("milestone_closed_count"))
-                .build()
+    public void adjustCount(String type, int delta) {
+        jdbcTemplate.update(
+                "UPDATE summary_count SET count = count + ? WHERE type = ?",
+                delta, type
         );
     }
 
-    public void incrementIssueOpen() {
-        jdbcTemplate.update(
-            "UPDATE summary_count SET issue_open_count = issue_open_count + 1 WHERE id = 1"
-        );
+    public void increment(String type) {
+        adjustCount(type, +1);
     }
-    public void decrementIssueOpen() {
-        jdbcTemplate.update(
-            "UPDATE summary_count SET issue_open_count = issue_open_count - 1 WHERE id = 1"
-        );
-    }
-    public void incrementIssueClosed() {
-        jdbcTemplate.update(
-            "UPDATE summary_count SET issue_closed_count = issue_closed_count + 1 WHERE id = 1"
-        );
-    }
-    public void decrementIssueClosed() {
-        jdbcTemplate.update(
-            "UPDATE summary_count SET issue_closed_count = issue_closed_count - 1 WHERE id = 1"
-        );
-    }
-    public void incrementMilestoneOpen() {
-        jdbcTemplate.update(
-            "UPDATE summary_count SET milestone_open_count = milestone_open_count + 1 WHERE id = 1"
-        );
-    }
-    public void decrementMilestoneOpen() {
-        jdbcTemplate.update("UPDATE summary_count SET milestone_open_count = milestone_open_count - 1 WHERE id = 1"
-        );
-    }
-    public void incrementMilestoneClosed() {
-        jdbcTemplate.update("UPDATE summary_count SET milestone_closed_count = milestone_closed_count + 1 WHERE id = 1"
-        );
-    }
-    public void decrementMilestoneClosed() {
-        jdbcTemplate.update("UPDATE summary_count SET milestone_closed_count = milestone_closed_count - 1 WHERE id = 1"
-        );
+
+    public void decrement(String type) {
+        adjustCount(type, -1);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/CountDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/CountDao.java
@@ -18,14 +18,14 @@ public class CountDao {
 
     public int getCount(String type) {
         return jdbcTemplate.queryForObject(
-                "SELECT count FROM summary_count WHERE type = ?",
+                "SELECT cnt FROM summary_count WHERE type = ?",
                 Integer.class, type
         );
     }
 
     public void adjustCount(String type, int delta) {
         jdbcTemplate.update(
-                "UPDATE summary_count SET count = count + ? WHERE type = ?",
+                "UPDATE summary_count SET cnt = cnt + ? WHERE type = ?",
                 delta, type
         );
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/CountService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/CountService.java
@@ -11,10 +11,14 @@ public class CountService {
     private final CountDao countDao;
 
     public IssueCountDto getIssueCounts() {
-        return countDao.getIssueCounts();
+        int open = countDao.getCount(CountDao.ISSUE_OPEN);
+        int closed = countDao.getCount(CountDao.ISSUE_CLOSED);
+        return new IssueCountDto(open, closed);
     }
 
     public MilestoneCountDto getMilestoneCounts() {
-        return countDao.getMilestoneCount();
+        int open = countDao.getCount(CountDao.MILESTONE_OPEN);
+        int closed = countDao.getCount(CountDao.MILESTONE_CLOSED);
+        return new MilestoneCountDto(open, closed);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
@@ -19,10 +19,10 @@ public class IssueCountListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onStatusChanged(IssueEvent.StatusChanged e) {
-        if (e.isOldIsOpen() && !e.isNewIsOpen()) {
+        if (e.isClosing()) {
             countDao.decrement(CountDao.ISSUE_OPEN);
             countDao.increment(CountDao.ISSUE_CLOSED);
-        } else if (!e.isOldIsOpen() && e.isNewIsOpen()) {
+        } else if (e.isOpening()) {
             countDao.increment(CountDao.ISSUE_OPEN);
             countDao.decrement(CountDao.ISSUE_CLOSED);
         }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
@@ -14,26 +14,26 @@ public class IssueCountListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onCreated(IssueEvent.Created e) {
-        countDao.incrementIssueOpen();
+        countDao.increment(CountDao.ISSUE_OPEN);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onStatusChanged(IssueEvent.StatusChanged e) {
         if (e.isOldIsOpen() && !e.isNewIsOpen()) {
-            countDao.decrementIssueOpen();
-            countDao.incrementIssueClosed();
+            countDao.decrement(CountDao.ISSUE_OPEN);
+            countDao.increment(CountDao.ISSUE_CLOSED);
         } else if (!e.isOldIsOpen() && e.isNewIsOpen()) {
-            countDao.incrementIssueOpen();
-            countDao.decrementIssueClosed();
+            countDao.increment(CountDao.ISSUE_OPEN);
+            countDao.decrement(CountDao.ISSUE_CLOSED);
         }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onDeleted(IssueEvent.Deleted e) {
         if (e.isWasOpen()) {
-            countDao.decrementIssueOpen();
+            countDao.decrement(CountDao.ISSUE_OPEN);
         } else {
-            countDao.decrementIssueClosed();
+            countDao.decrement(CountDao.ISSUE_CLOSED);
         }
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
@@ -16,26 +16,26 @@ public class MilestoneCountListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onCreated(MilestoneEvent.Created e) {
-        countDao.incrementMilestoneOpen();
+        countDao.increment(CountDao.MILESTONE_OPEN);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onStatusChanged(MilestoneEvent.StatusChanged e) {
         if (e.isOldIsOpen() && !e.isNewIsOpen()) {
-            countDao.decrementMilestoneOpen();
-            countDao.incrementMilestoneClosed();
+            countDao.decrement(CountDao.MILESTONE_OPEN);
+            countDao.increment(CountDao.MILESTONE_CLOSED);
         } else if (!e.isOldIsOpen() && e.isNewIsOpen()) {
-            countDao.incrementMilestoneOpen();
-            countDao.decrementMilestoneClosed();
+            countDao.increment(CountDao.MILESTONE_OPEN);
+            countDao.decrement(CountDao.MILESTONE_CLOSED);
         }
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onDeleted(MilestoneEvent.Deleted e) {
         if (e.isWasOpen()) {
-            countDao.decrementMilestoneOpen();
+            countDao.decrement(CountDao.MILESTONE_OPEN);
         } else {
-            countDao.decrementMilestoneClosed();
+            countDao.decrement(CountDao.MILESTONE_CLOSED);
         }
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
@@ -21,10 +21,10 @@ public class MilestoneCountListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onStatusChanged(MilestoneEvent.StatusChanged e) {
-        if (e.isOldIsOpen() && !e.isNewIsOpen()) {
+        if (e.isClosing()) {
             countDao.decrement(CountDao.MILESTONE_OPEN);
             countDao.increment(CountDao.MILESTONE_CLOSED);
-        } else if (!e.isOldIsOpen() && e.isNewIsOpen()) {
+        } else if (e.isOpening()) {
             countDao.increment(CountDao.MILESTONE_OPEN);
             countDao.decrement(CountDao.MILESTONE_CLOSED);
         }

--- a/backend/src/main/java/codesquad/team4/issuetracker/entity/User.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/entity/User.java
@@ -26,6 +26,9 @@ public class User {
     @Column("profile_image")
     private String profileImage;
 
+    @Column("password")
+    private String password;
+
     @Column("created_at")
     private LocalDateTime createdAt;
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -12,4 +12,6 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_COMMENT = "댓글을 찾을 수 없습니다. commentId = ";
     public static final String INVALID_COMMENT_ACCESS = "댓글이 이슈에 속하지 않습니다.";
     public static final String INVALID_FILTERING_CONDITION = "authorId, assigneeId, commentAuthorId 중 하나만 사용할 수 있습니다.";
+    public static final String EMAIL_ALREADY_EXIST = "이미 존재하는 이메일입니다";
+    public static final String NICKNAME_ALREADY_EXIST = "이미 존재하는 닉네임입니다";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -14,4 +14,6 @@ public class ExceptionMessage {
     public static final String INVALID_FILTERING_CONDITION = "authorId, assigneeId, commentAuthorId 중 하나만 사용할 수 있습니다.";
     public static final String EMAIL_ALREADY_EXIST = "이미 존재하는 이메일입니다";
     public static final String NICKNAME_ALREADY_EXIST = "이미 존재하는 닉네임입니다";
+    public static final String USER_BY_EMAIL_NOT_EXIST = "이메일이 일치하는 회원이 없습니다";
+    public static final String USER_PASSWORD_NOT_EQUAL = "비밀번호가 일치하지 않습니다";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package codesquad.team4.issuetracker.exception;
 import codesquad.team4.issuetracker.exception.badrequest.InvalidRequestException;
 import codesquad.team4.issuetracker.exception.conflict.ConflictException;
 import codesquad.team4.issuetracker.exception.notfound.DataNotFoundException;
+import codesquad.team4.issuetracker.exception.unauthorized.UnauthorizedException;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.HttpStatus;
@@ -30,6 +31,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConflictException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     public ApiResponse<String> handleConflictException(ConflictException ex) {
+        return ApiResponse.fail(ex.getMessage());
+    }
+
+    @ExceptionHandler(UnauthorizedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ApiResponse<String> handleUnauthorizedException(UnauthorizedException ex) {
         return ApiResponse.fail(ex.getMessage());
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package codesquad.team4.issuetracker.exception;
 
 import codesquad.team4.issuetracker.exception.badrequest.InvalidRequestException;
+import codesquad.team4.issuetracker.exception.conflict.ConflictException;
 import codesquad.team4.issuetracker.exception.notfound.DataNotFoundException;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Hidden
@@ -23,5 +25,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<String>> handleBadRequestException(InvalidRequestException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(ex.getMessage()));
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ApiResponse<String> handleConflictException(ConflictException ex) {
+        return ApiResponse.fail(ex.getMessage());
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/PasswordNotEqualException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/badrequest/PasswordNotEqualException.java
@@ -1,0 +1,9 @@
+package codesquad.team4.issuetracker.exception.badrequest;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.USER_PASSWORD_NOT_EQUAL;
+
+public class PasswordNotEqualException extends InvalidRequestException {
+    public PasswordNotEqualException() {
+        super(USER_PASSWORD_NOT_EQUAL);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/conflict/ConflictException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/conflict/ConflictException.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.exception.conflict;
+
+abstract public class ConflictException extends RuntimeException{
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/conflict/EmailAlreadyExistException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/conflict/EmailAlreadyExistException.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.exception.conflict;
+
+public class EmailAlreadyExistException extends ConflictException{
+    public EmailAlreadyExistException(String message) {
+        super (message);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/conflict/NicknameAlreadyExistException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/conflict/NicknameAlreadyExistException.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.exception.conflict;
+
+public class NicknameAlreadyExistException extends ConflictException{
+    public NicknameAlreadyExistException(String message) {
+        super (message);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/notfound/UserByEmailNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/notfound/UserByEmailNotFoundException.java
@@ -1,0 +1,10 @@
+package codesquad.team4.issuetracker.exception.notfound;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.USER_BY_EMAIL_NOT_EXIST;
+
+public class UserByEmailNotFoundException extends DataNotFoundException {
+
+    public UserByEmailNotFoundException() {
+        super(USER_BY_EMAIL_NOT_EXIST);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/PasswordNotEqualException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/PasswordNotEqualException.java
@@ -1,8 +1,8 @@
-package codesquad.team4.issuetracker.exception.badrequest;
+package codesquad.team4.issuetracker.exception.unauthorized;
 
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.USER_PASSWORD_NOT_EQUAL;
 
-public class PasswordNotEqualException extends InvalidRequestException {
+public class PasswordNotEqualException extends UnauthorizedException {
     public PasswordNotEqualException() {
         super(USER_PASSWORD_NOT_EQUAL);
     }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/UnauthorizedException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.exception.unauthorized;
+
+abstract public class UnauthorizedException extends RuntimeException{
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/UserByEmailNotFoundException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/UserByEmailNotFoundException.java
@@ -1,8 +1,8 @@
-package codesquad.team4.issuetracker.exception.notfound;
+package codesquad.team4.issuetracker.exception.unauthorized;
 
 import static codesquad.team4.issuetracker.exception.ExceptionMessage.USER_BY_EMAIL_NOT_EXIST;
 
-public class UserByEmailNotFoundException extends DataNotFoundException {
+public class UserByEmailNotFoundException extends UnauthorizedException {
 
     public UserByEmailNotFoundException() {
         super(USER_BY_EMAIL_NOT_EXIST);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -39,9 +39,10 @@ public class IssueController {
     private final S3FileService s3FileService;
 
     @GetMapping("")
-    public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(@RequestParam(required = false) String q, Pageable pageable) {
+    public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(
+        @RequestParam(required = false, name = "q") String queryString, Pageable pageable) {
 
-        IssueFilterParamDto filter = IssueFilteringParser.parseFilterCondition(q);
+        IssueFilterParamDto filter = IssueFilteringParser.parseFilterCondition(queryString);
         IssueResponseDto.IssueListDto issues = issueService.getIssues(filter, pageable.getPageNumber(), pageable.getPageSize());
 
         return ApiResponse.success(issues);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -6,7 +6,7 @@ import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDt
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
-import codesquad.team4.issuetracker.util.Parser;
+import codesquad.team4.issuetracker.util.IssueFilteringParser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +41,7 @@ public class IssueController {
     @GetMapping("")
     public ApiResponse<IssueResponseDto.IssueListDto> showIssueList(@RequestParam(required = false) String q, Pageable pageable) {
 
-        IssueFilterParamDto filter = Parser.parseFilterCondition(q);
+        IssueFilterParamDto filter = IssueFilteringParser.parseFilterCondition(q);
         IssueResponseDto.IssueListDto issues = issueService.getIssues(filter, pageable.getPageNumber(), pageable.getPageSize());
 
         return ApiResponse.success(issues);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -1,15 +1,13 @@
     package codesquad.team4.issuetracker.issue;
 
-    import static codesquad.team4.issuetracker.util.Parser.camelToSnake;
+    import static codesquad.team4.issuetracker.util.IssueFilteringParser.camelToSnake;
 
     import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
     import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
     import java.util.ArrayList;
     import java.util.HashMap;
-    import java.util.HashSet;
     import java.util.List;
     import java.util.Map;
-    import java.util.Set;
     import java.util.stream.Collectors;
     import lombok.RequiredArgsConstructor;
     import lombok.extern.slf4j.Slf4j;

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueEvent.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueEvent.java
@@ -10,9 +10,17 @@ public class IssueEvent {
 
     @AllArgsConstructor
     @Getter
-    public static class StatusChanged { //상태 변경 oㅣd -> new
+    public static class StatusChanged { //상태 변경 old -> new
         private final boolean oldIsOpen;
         private final boolean newIsOpen;
+        //open -> closed
+        public boolean isClosing() {
+            return oldIsOpen && !newIsOpen;
+        }
+        //closed -> open
+        public boolean isOpening() {
+            return !oldIsOpen && newIsOpen;
+        }
     }
 
     @AllArgsConstructor

--- a/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneEvent.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/milestone/MilestoneEvent.java
@@ -9,9 +9,17 @@ public class MilestoneEvent {
 
     @AllArgsConstructor
     @Getter
-    public static class StatusChanged {
+    public static class StatusChanged { //상태 변경 old -> new
         private final boolean oldIsOpen;
         private final boolean newIsOpen;
+        //open -> closed
+        public boolean isClosing() {
+            return oldIsOpen && !newIsOpen;
+        }
+        //closed -> open
+        public boolean isOpening() {
+            return !oldIsOpen && newIsOpen;
+        }
     }
 
     @AllArgsConstructor

--- a/backend/src/main/java/codesquad/team4/issuetracker/user/UserRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/user/UserRepository.java
@@ -1,0 +1,9 @@
+package codesquad.team4.issuetracker.user;
+
+import codesquad.team4.issuetracker.entity.User;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface UserRepository extends CrudRepository<User, Long> {
+    Optional<User> findByEmailOrNickname(String email, String nickname);
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/user/UserRepository.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/user/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.repository.CrudRepository;
 
 public interface UserRepository extends CrudRepository<User, Long> {
     Optional<User> findByEmailOrNickname(String email, String nickname);
+
+    Optional<User> findByEmail(String email);
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/util/IssueFilteringParser.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/util/IssueFilteringParser.java
@@ -5,7 +5,7 @@ import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDt
 import java.util.ArrayList;
 import java.util.List;
 
-public class Parser {
+public class IssueFilteringParser {
     public static IssueRequestDto.IssueFilterParamDto parseFilterCondition(String query) {
         String[] conditions = query.split(" ");
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/util/OpenStatus.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/util/OpenStatus.java
@@ -6,21 +6,24 @@ import lombok.Getter;
 public enum OpenStatus{
     OPEN("open", true), CLOSE("close", false);
 
-    final String value;
-    final boolean state;
+    private final String value;
+    private final boolean state;
+    private static final OpenStatus[] VALUES = OpenStatus.values();
 
     OpenStatus(String value, boolean state) {
         this.value = value;
         this.state = state;
     }
+
     public static OpenStatus fromValue(String value) {
-        for (OpenStatus status : OpenStatus.values()) {
+        for (OpenStatus status : VALUES) {
             if (status.value.equalsIgnoreCase(value)) {
                 return status;
             }
         }
         return OpenStatus.OPEN;
     }
+
     public boolean getState() {
         return state;
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -41,3 +41,6 @@ springdoc:
         url: /issue-tracker/api-docs
 profile:
     default-image-url: ${DEFAULT_PROFILE_URL}
+
+jwt:
+    secret: ${JWT_SECRET}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -39,3 +39,5 @@ springdoc:
     swagger-ui:
         path: /issue-tracker/swagger-ui.html
         url: /issue-tracker/api-docs
+profile:
+    default-image-url: ${DEFAULT_PROFILE_URL}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -84,15 +84,13 @@ CREATE TABLE issue_assignee (
 
 -- 1) summary_count 테이블 생성
 CREATE TABLE summary_count (
-                               id TINYINT PRIMARY KEY DEFAULT 1,
-                               issue_open_count     INT NOT NULL DEFAULT 0,
-                               issue_closed_count   INT NOT NULL DEFAULT 0,
-                               milestone_open_count INT NOT NULL DEFAULT 0,
-                               milestone_closed_count INT NOT NULL DEFAULT 0,
-                               labels_count         INT NOT NULL DEFAULT 0,
-                               milestones_count     INT NOT NULL DEFAULT 0
+                               type  VARCHAR(50) PRIMARY KEY,
+                               count INT NOT NULL DEFAULT 0
 );
 
--- 2) 초기 row 삽입 (id=1 고정)
-INSERT INTO summary_count (id) VALUES (1)
-ON DUPLICATE KEY UPDATE id = 1;
+-- 2) 초기 row 삽입
+INSERT INTO summary_count(type) VALUES
+                                    ('issue_open'),
+                                    ('issue_closed'),
+                                    ('milestone_open'),
+                                    ('milestone_closed');

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -4,6 +4,7 @@ CREATE TABLE user (
                       email VARCHAR(255) NOT NULL UNIQUE,
                       nickname VARCHAR(255) NOT NULL UNIQUE,
                       profile_image VARCHAR(255),
+                      password VARCHAR(255) NOT NULL,
                       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -85,7 +85,7 @@ CREATE TABLE issue_assignee (
 -- 1) summary_count 테이블 생성
 CREATE TABLE summary_count (
                                type  VARCHAR(50) PRIMARY KEY,
-                               count INT NOT NULL DEFAULT 0
+                               cnt INT NOT NULL DEFAULT 0
 );
 
 -- 2) 초기 row 삽입

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthControllerTest.java
@@ -1,0 +1,98 @@
+package codesquad.team4.issuetracker.auth;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import codesquad.team4.issuetracker.auth.dto.AuthRequestDto;
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.unauthorized.UserByEmailNotFoundException;
+import codesquad.team4.issuetracker.user.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AuthController.class)
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private AuthInterceptor authInterceptor;
+
+    private User dummyUser;
+
+    @BeforeEach
+    void setUp() {
+        dummyUser = User.builder()
+            .id(1L)
+            .email("test@example.com")
+            .nickname("테스터")
+            .password("encodedPassword")
+            .profileImage("image.png")
+            .build();
+    }
+
+    @Test
+    @DisplayName("로그인 성공시 유저 정보와 쿠키에 토큰을 반환한다")
+    void loginSuccessTest() throws Exception {
+        // given
+        AuthRequestDto.LoginRequestDto loginRequest = new AuthRequestDto.LoginRequestDto("test@example.com", "1234");
+        String jwtToken = "mocked-jwt-token";
+
+        given(authService.checkEmailAndPassword(any())).willReturn(dummyUser);
+        given(jwtProvider.createToken(dummyUser.getId())).willReturn(jwtToken);
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.userId").value(dummyUser.getId()))
+            .andExpect(jsonPath("$.data.nickname").value(dummyUser.getNickname()))
+            .andExpect(jsonPath("$.data.profileImage").value(dummyUser.getProfileImage()))
+            .andExpect(header().string("Set-Cookie", containsString("jwt=")))
+            .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
+            .andExpect(header().string("Set-Cookie", containsString("SameSite=Strict")))
+            .andExpect(header().string("Set-Cookie", containsString("Max-Age=86400")));
+    }
+
+    @Test
+    @DisplayName("로그인 실패시 401 Unauthorized를 반환한다")
+    void loginFailTest() throws Exception {
+        // given
+        AuthRequestDto.LoginRequestDto loginRequest = new AuthRequestDto.LoginRequestDto("wrong@example.com", "wrongpw");
+
+        given(authService.checkEmailAndPassword(any()))
+            .willThrow(new UserByEmailNotFoundException());
+
+        // when & then
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(loginRequest)))
+            .andExpect(status().isUnauthorized());
+    }
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceH2Test.java
@@ -1,7 +1,7 @@
 package codesquad.team4.issuetracker.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
 import codesquad.team4.issuetracker.entity.User;
@@ -29,7 +29,7 @@ public class AuthServiceH2Test {
     @DisplayName("비밀번호는 해싱된 후 DB에 저장되어야 한다")
     void passwordShouldBeHashed() {
         // given
-        SignupRequestDto request = new SignupRequestDto("test@email.com", "nickname", "plainPassword");
+        SignupRequestDto request = new SignupRequestDto("test@email.com", "plainPassword", "nickname");
 
         // when
         authService.createNewUser(request);
@@ -38,7 +38,7 @@ public class AuthServiceH2Test {
         // then
         assertThat(savedUser.getPassword()).isNotEqualTo("plainPassword");
         //무작위 솔트 값으로 인해 해싱마다 변경
-        assertFalse(BCrypt.checkpw("plainPassword", savedUser.getPassword()));
+        assertTrue(BCrypt.checkpw("plainPassword", savedUser.getPassword()));
     }
 
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceH2Test.java
@@ -1,0 +1,44 @@
+package codesquad.team4.issuetracker.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+public class AuthServiceH2Test {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    AuthService authService;
+
+    @Test
+    @DisplayName("비밀번호는 해싱된 후 DB에 저장되어야 한다")
+    void passwordShouldBeHashed() {
+        // given
+        SignupRequestDto request = new SignupRequestDto("test@email.com", "nickname", "plainPassword");
+
+        // when
+        authService.createNewUser(request);
+        User savedUser = userRepository.findByEmailOrNickname("test@email.com", "nickname").orElseThrow();
+
+        // then
+        assertThat(savedUser.getPassword()).isNotEqualTo("plainPassword");
+        //무작위 솔트 값으로 인해 해싱마다 변경
+        assertFalse(BCrypt.checkpw("plainPassword", savedUser.getPassword()));
+    }
+
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/AuthServiceTest.java
@@ -1,0 +1,63 @@
+package codesquad.team4.issuetracker.auth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import codesquad.team4.issuetracker.auth.dto.AuthRequestDto.SignupRequestDto;
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.conflict.EmailAlreadyExistException;
+import codesquad.team4.issuetracker.exception.conflict.NicknameAlreadyExistException;
+import codesquad.team4.issuetracker.user.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AuthService authService;
+
+
+    @Test
+    @DisplayName("DB에 같은 이메일이 존재하면 예외가 발생한다")
+    void emailDuplicateSignupTest() {
+        SignupRequestDto request = new SignupRequestDto("duplicate@example.com", "password", "nickname");
+
+        User existingUser = User.builder()
+            .id(1L)
+            .email("duplicate@example.com")
+            .nickname("otherNickname")
+            .build();
+
+        given(userRepository.findByEmailOrNickname("duplicate@example.com", "nickname"))
+            .willReturn(Optional.of(existingUser));
+
+        assertThatThrownBy(() -> authService.createNewUser(request))
+            .isInstanceOf(EmailAlreadyExistException.class);
+    }
+
+    @Test
+    @DisplayName("DB에 같은 닉네임이 존재하면 예외가 발생한다")
+    void nicknameDuplicateSignupTest() {
+        SignupRequestDto request = new SignupRequestDto("test@example.com", "password", "duplicatedNickname");
+
+        User existingUser = User.builder()
+            .id(1L)
+            .email("other@example.com")
+            .nickname("duplicatedNickname")
+            .build();
+
+        given(userRepository.findByEmailOrNickname("test@example.com", "duplicatedNickname"))
+            .willReturn(Optional.of(existingUser));
+
+        assertThatThrownBy(() -> authService.createNewUser(request))
+            .isInstanceOf(NicknameAlreadyExistException.class);
+    }
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/auth/JwtProviderTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/auth/JwtProviderTest.java
@@ -1,0 +1,80 @@
+package codesquad.team4.issuetracker.auth;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class JwtProviderTest {
+
+    private JwtProvider jwtProvider;
+
+    private final String secret = "testsecrettestsecrettestsecrettestsecret"; // 32 bytes 이상
+
+    @BeforeEach
+    void setUp() {
+        jwtProvider = new JwtProvider();
+        ReflectionTestUtils.setField(jwtProvider, "secret", secret);
+    }
+
+    @Test
+    @DisplayName("JWT 토큰이 생성되면 userId를 파싱할 수 있다")
+    void createAndParseToken() {
+        //given
+        Long userId = 123L;
+
+        //when
+        String token = jwtProvider.createToken(userId);
+        Long parsedUserId = jwtProvider.getUserId(token);
+
+        //then
+        assertThat(token).isNotBlank();
+        assertThat(parsedUserId).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("유효한 토큰이면 isValid가 true를 반환한다")
+    void isValid_validToken() {
+        //when
+        String token = jwtProvider.createToken(1L);
+        boolean isValid = jwtProvider.isValid(token);
+
+        //then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰이면 isValid가 false를 반환한다")
+    void isValid_invalidToken() {
+        //when
+        String invalidToken = "InvalidToken";
+        boolean isValid = jwtProvider.isValid(invalidToken);
+
+        //then
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰이면 isValid가 false를 반환한다")
+    void isValid_expiredToken(){
+
+        Date now = new Date();
+        Date expiredAt = new Date(now.getTime() - 1000); // 이미 만료된 시점
+
+        String expiredToken = Jwts.builder()
+            .setSubject("1")
+            .setIssuedAt(now)
+            .setExpiration(expiredAt) // 만료된 시간
+            .signWith(Keys.hmacShaKeyFor(secret.getBytes()), SignatureAlgorithm.HS256)
+            .compact();
+
+        boolean isValid = jwtProvider.isValid(expiredToken);
+        assertThat(isValid).isFalse();
+    }
+}

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import codesquad.team4.issuetracker.auth.AuthInterceptor;
 import codesquad.team4.issuetracker.aws.S3FileService;
 import codesquad.team4.issuetracker.comment.dto.CommentResponseDto;
 import codesquad.team4.issuetracker.exception.badrequest.FileUploadException;
@@ -18,7 +19,9 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,71 +42,79 @@ class IssueControllerTest {
     @MockitoBean
     private S3FileService s3FileService;
 
+    @MockitoBean
+    private AuthInterceptor authInterceptor;
+
     @Autowired
     private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        given(authInterceptor.preHandle(any(), any(), any())).willReturn(true);
+    }
 
     @Test
     @DisplayName("파일과 이슈 데이터로 이슈를 생성할 수 있다")
     void createIssue_success() throws Exception {
         // given
         IssueRequestDto.CreateIssueDto requestDto = IssueRequestDto.CreateIssueDto.builder()
-                .title("이슈 제목")
-                .content("이슈 설명")
-                .authorId(1L)
-                .build();
+            .title("이슈 제목")
+            .content("이슈 설명")
+            .authorId(1L)
+            .build();
 
         String jsonPart = objectMapper.writeValueAsString(requestDto);
 
         MockMultipartFile jsonFile = new MockMultipartFile(
-                "issue", "", "application/json", jsonPart.getBytes());
+            "issue", "", "application/json", jsonPart.getBytes());
 
         MockMultipartFile file = new MockMultipartFile(
-                "file", "image.png", "image/png", "image-content".getBytes());
+            "file", "image.png", "image/png", "image-content".getBytes());
 
         given(s3FileService.uploadFile(any(), eq("issue/"))).willReturn("https://fake-s3-url/image.png");
 
         ApiMessageDto responseDto = ApiMessageDto.builder()
-                .id(1L)
-                .message("이슈가 생성되었습니다.")
-                .build();
+            .id(1L)
+            .message("이슈가 생성되었습니다.")
+            .build();
 
         given(issueService.createIssue(any(), any())).willReturn(responseDto);
 
         // when & then
         mockMvc.perform(multipart("/api/issues")
-                        .file(jsonFile)
-                        .file(file)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(1L))
-                .andExpect(jsonPath("$.data.message").value("이슈가 생성되었습니다."));
+                .file(jsonFile)
+                .file(file)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.id").value(1L))
+            .andExpect(jsonPath("$.data.message").value("이슈가 생성되었습니다."));
     }
 
     @Test
     @DisplayName("파일 업로드 실패시 BadRequest를 반환한다")
     void createIssue_fileUploadFail() throws Exception {
         IssueRequestDto.CreateIssueDto requestDto = IssueRequestDto.CreateIssueDto.builder()
-                .title("이슈 제목")
-                .content("이슈 설명")
-                .authorId(1L)
-                .build();
+            .title("이슈 제목")
+            .content("이슈 설명")
+            .authorId(1L)
+            .build();
 
         String jsonPart = objectMapper.writeValueAsString(requestDto);
 
         MockMultipartFile jsonFile = new MockMultipartFile(
-                "issue", "", "application/json", jsonPart.getBytes());
+            "issue", "", "application/json", jsonPart.getBytes());
 
         MockMultipartFile file = new MockMultipartFile(
-                "file", "image.png", "image/png", "image-content".getBytes());
+            "file", "image.png", "image/png", "image-content".getBytes());
 
         given(s3FileService.uploadFile(any(), eq("issues/"))).willThrow(new FileUploadException("파일 업로드에 실패했습니다."));
 
         mockMvc.perform(multipart("/api/issues")
-                        .file(jsonFile)
-                        .file(file)
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("파일 업로드에 실패했습니다."));
+                .file(jsonFile)
+                .file(file)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("파일 업로드에 실패했습니다."));
     }
 
     @Test
@@ -111,27 +122,27 @@ class IssueControllerTest {
     void bulkUpdateIssueStatus_success() throws Exception {
         // given
         IssueRequestDto.BulkUpdateIssueStatusDto requestDto = IssueRequestDto.BulkUpdateIssueStatusDto.builder()
-                .issuesId(List.of(1L, 2L, 3L))
-                .isOpen(false)
-                .build();
+            .issuesId(List.of(1L, 2L, 3L))
+            .isOpen(false)
+            .build();
 
         IssueResponseDto.BulkUpdateIssueStatusDto responseDto = IssueResponseDto.BulkUpdateIssueStatusDto.builder()
-                .issuesId(List.of(1L, 2L, 3L))
-                .message("이슈 상태가 변경되었습니다.")
-                .build();
+            .issuesId(List.of(1L, 2L, 3L))
+            .message("이슈 상태가 변경되었습니다.")
+            .build();
 
         given(issueService.bulkUpdateIssueStatus(any())).willReturn(responseDto);
 
         // when & then
         mockMvc.perform(
-                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/issues/status")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.issuesId[0]").value(1))
-                .andExpect(jsonPath("$.data.issuesId[1]").value(2))
-                .andExpect(jsonPath("$.data.issuesId[2]").value(3))
-                .andExpect(jsonPath("$.data.message").value("이슈 상태가 변경되었습니다."));
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/issues/status")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.issuesId[0]").value(1))
+            .andExpect(jsonPath("$.data.issuesId[1]").value(2))
+            .andExpect(jsonPath("$.data.issuesId[2]").value(3))
+            .andExpect(jsonPath("$.data.message").value("이슈 상태가 변경되었습니다."));
     }
 
     @Test
@@ -139,20 +150,20 @@ class IssueControllerTest {
     void bulkUpdateIssueStatus_failure() throws Exception {
         // given
         IssueRequestDto.BulkUpdateIssueStatusDto requestDto = IssueRequestDto.BulkUpdateIssueStatusDto.builder()
-                .issuesId(List.of(1L, 999L))
-                .isOpen(false)
-                .build();
+            .issuesId(List.of(1L, 999L))
+            .isOpen(false)
+            .build();
 
         given(issueService.bulkUpdateIssueStatus(any()))
-                .willThrow(new IssueStatusUpdateException("일부 이슈 ID가 존재하지 않습니다."));
+            .willThrow(new IssueStatusUpdateException("일부 이슈 ID가 존재하지 않습니다."));
 
         // when & then
         mockMvc.perform(
-                        org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/issues/status")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(requestDto)))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("일부 이슈 ID가 존재하지 않습니다."));
+                org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch("/api/issues/status")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(requestDto)))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value("일부 이슈 ID가 존재하지 않습니다."));
     }
 
     @Test
@@ -162,12 +173,12 @@ class IssueControllerTest {
         Long notExistIssueId = 999L;
 
         given(issueService.getIssueDetailById(notExistIssueId))
-                .willThrow(new IssueNotFoundException(notExistIssueId));
+            .willThrow(new IssueNotFoundException(notExistIssueId));
 
         // when & then
         mockMvc.perform(get("/api/issues/{issue-id}", notExistIssueId))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("이슈를 찾을 수 없습니다. issueId = " + notExistIssueId));
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value("이슈를 찾을 수 없습니다. issueId = " + notExistIssueId));
     }
 
     @Test
@@ -177,37 +188,38 @@ class IssueControllerTest {
         Long issueId = 1L;
 
         IssueResponseDto.searchIssueDetailDto responseDto =
-                IssueResponseDto.searchIssueDetailDto.builder()
-                        .content("이슈 설명")
-                        .comments(List.of(
-                                CommentResponseDto.CommentInfo.builder()
-                                        .commentId(1L)
-                                        .content("댓글1")
-                                        .author(UserDto.UserInfo.builder()
-                                                .id(1L)
-                                                .nickname("작성자1")
-                                                .build())
-                                        .build(),
-                                CommentResponseDto.CommentInfo.builder()
-                                        .commentId(2L)
-                                        .content("댓글2")
-                                        .author(UserDto.UserInfo.builder()
-                                                .id(2L)
-                                                .nickname("작성자2")
-                                                .build())
-                                        .build()))
-                        .build();
+            IssueResponseDto.searchIssueDetailDto.builder()
+                .content("이슈 설명")
+                .comments(List.of(
+                    CommentResponseDto.CommentInfo.builder()
+                        .commentId(1L)
+                        .content("댓글1")
+                        .author(UserDto.UserInfo.builder()
+                            .id(1L)
+                            .nickname("작성자1")
+                            .build())
+                        .build(),
+                    CommentResponseDto.CommentInfo.builder()
+                        .commentId(2L)
+                        .content("댓글2")
+                        .author(UserDto.UserInfo.builder()
+                            .id(2L)
+                            .nickname("작성자2")
+                            .build())
+                        .build()))
+                .build();
 
         given(issueService.getIssueDetailById(issueId)).willReturn(responseDto);
 
         // when & then
         mockMvc.perform(get("/api/issues/{issue-id}", issueId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.content").value("이슈 설명"))
-                .andExpect(jsonPath("$.data.comments").isArray())
-                .andExpect(jsonPath("$.data.comments[0].content").value("댓글1"))
-                .andExpect(jsonPath("$.data.comments[0].author.nickname").value("작성자1"))
-                .andExpect(jsonPath("$.data.comments[1].content").value("댓글2"))
-                .andExpect(jsonPath("$.data.comments[1].author.nickname").value("작성자2"));
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.content").value("이슈 설명"))
+            .andExpect(jsonPath("$.data.comments").isArray())
+            .andExpect(jsonPath("$.data.comments[0].content").value("댓글1"))
+            .andExpect(jsonPath("$.data.comments[0].author.nickname").value("작성자1"))
+            .andExpect(jsonPath("$.data.comments[1].content").value("댓글2"))
+            .andExpect(jsonPath("$.data.comments[1].author.nickname").value("작성자2"));
     }
+
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -274,7 +274,7 @@ class IssueServiceH2Test {
     }
 
     @ParameterizedTest
-    @MethodSource("codesquad.team4.issuetracker.util.ParserTest#provideFilterConditions")
+    @MethodSource("codesquad.team4.issuetracker.util.IssueFilteringParserTest#provideFilterConditions")
     @DisplayName("필터링 조건이 주어졌을 때 서비스에서 올바른 이슈 목록을 반환한다")
     void filterIssuesInService(
         String q, String state, Long authorId, Long assigneeId,

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -12,7 +12,7 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueListDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.util.OpenStatus;
-import codesquad.team4.issuetracker.util.Parser;
+import codesquad.team4.issuetracker.util.IssueFilteringParser;
 import codesquad.team4.issuetracker.util.TestDataHelper;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -281,7 +281,7 @@ class IssueServiceH2Test {
         Long milestoneId, Long commentAuthorId, List<Long> labelIds) {
 
         // given
-        IssueRequestDto.IssueFilterParamDto filterDto = Parser.parseFilterCondition(q);
+        IssueRequestDto.IssueFilterParamDto filterDto = IssueFilteringParser.parseFilterCondition(q);
 
         // when
         IssueResponseDto.IssueListDto result = issueService.getIssues(filterDto, 0, 10);

--- a/backend/src/test/java/codesquad/team4/issuetracker/milestone/MilestoneServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/milestone/MilestoneServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,7 +52,13 @@ public class MilestoneServiceTest {
         TestDataHelper.insertUser(jdbcTemplate, 1L, "user1");
         TestDataHelper.insertIssueAllParams(jdbcTemplate, 1L, "issue1", true, 1L, "1111", null, 1L);
         TestDataHelper.insertIssueAllParams(jdbcTemplate, 2L, "issue2", false, 1L, "2222", null, 1L);
-        TestDataHelper.insertSummaryCount(jdbcTemplate, 1, 1, 1, 1, 1,0, 0);
+        Map<String, Integer> summaryMap = Map.of(
+                "issue_open", 1,
+                "issue_closed", 1,
+                "milestone_open", 1,
+                "milestone_closed", 1
+        );
+        TestDataHelper.insertSummaryCount(jdbcTemplate, summaryMap);
     }
     @Test
     @DisplayName("마일스톤 필터링 정보 조회")

--- a/backend/src/test/java/codesquad/team4/issuetracker/user/UserServiceTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/user/UserServiceTest.java
@@ -1,5 +1,7 @@
 package codesquad.team4.issuetracker.user;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import codesquad.team4.issuetracker.user.dto.UserDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,8 +12,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @DataJdbcTest
@@ -28,10 +28,10 @@ class UserServiceTest {
     @BeforeEach
     void setUp() {
         jdbcTemplate.update("""
-            INSERT INTO `user` (user_id, email, nickname, profile_image, created_at, updated_at)
-            VALUES 
-                (1, 'user1@test.com', 'user1', 'image.com/a.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-                (2, 'user2@test.com', 'user2', 'image.com/b.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            INSERT INTO `user` (user_id, email, nickname, profile_image, created_at, updated_at, password)
+            VALUES
+                (1, 'user1@test.com', 'user1', 'image.com/a.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'password'),
+                (2, 'user2@test.com', 'user2', 'image.com/b.jpg', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'password')
         """);
     }
 

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/IssueFilteringParserTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/IssueFilteringParserTest.java
@@ -10,13 +10,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class ParserTest {
+public class IssueFilteringParserTest {
     @ParameterizedTest
     @MethodSource("provideFilterConditions")
     @DisplayName("문자열 필터링 조건을 파싱하여 Dto로 만든다")
     void filteringConditionToDto(String q, String state, Long authorId, Long assigneeId, Long milestoneId, Long commentAuthorId, List<Long> labelIds) {
         // when
-        IssueRequestDto.IssueFilterParamDto filterDto = Parser.parseFilterCondition(q);
+        IssueRequestDto.IssueFilterParamDto filterDto = IssueFilteringParser.parseFilterCondition(q);
 
         // then
         assertThat(filterDto.getStatus().getValue()).isEqualTo(state);

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
@@ -1,6 +1,8 @@
 package codesquad.team4.issuetracker.util;
 
 import java.time.LocalDate;
+import java.util.Map;
+
 import org.springframework.jdbc.core.JdbcTemplate;
 
 public class TestDataHelper {
@@ -59,22 +61,11 @@ public class TestDataHelper {
     }
 
     public static void insertSummaryCount(JdbcTemplate jdbcTemplate,
-                                          int id,
-                                          int issueOpenCount,
-                                          int issueClosedCount,
-                                          int milestoneOpenCount,
-                                          int milestoneClosedCount,
-                                          int labelsCount,
-                                          int milestonesCount) {
-        jdbcTemplate.update("""
-        UPDATE summary_count SET
-            issue_open_count = ?,
-            issue_closed_count = ?,
-            milestone_open_count = ?,
-            milestone_closed_count = ?,
-            labels_count = ?,
-            milestones_count = ?
-        WHERE id = 1
-    """, issueOpenCount, issueClosedCount, milestoneOpenCount, milestoneClosedCount, labelsCount, milestonesCount);
+                                          Map<String, Integer> summaryMap) {
+        String sql = "UPDATE summary_count SET cnt = ? WHERE type = ?";
+
+        for (Map.Entry<String, Integer> entry : summaryMap.entrySet()) {
+            jdbcTemplate.update(sql, entry.getValue(), entry.getKey());
+        }
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/TestDataHelper.java
@@ -7,9 +7,9 @@ public class TestDataHelper {
 
     public static void insertUser(JdbcTemplate jdbcTemplate, Long id, String nickname) {
         jdbcTemplate.update("""
-            INSERT INTO `user` (user_id, email, nickname)
-            VALUES (?, ?, ?)
-        """, id, "user" + id + "@test.com", nickname);
+            INSERT INTO `user` (user_id, email, nickname, password)
+            VALUES (?, ?, ?, ?)
+        """, id, "user" + id + "@test.com", nickname, "password");
     }
 
     public static void insertIssue(JdbcTemplate jdbcTemplate, Long id, String title, boolean isOpen, Long authorId) {

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -82,14 +82,15 @@ CREATE TABLE issue_assignee (
                                 CONSTRAINT fk_issue_assignee_user FOREIGN KEY (assignee_id) REFERENCES `user`(user_id)
 );
 
+-- 1) summary_count 테이블 생성
 CREATE TABLE summary_count (
-                               id TINYINT PRIMARY KEY,
-                               issue_open_count     INT NOT NULL DEFAULT 0,
-                               issue_closed_count   INT NOT NULL DEFAULT 0,
-                               milestone_open_count INT NOT NULL DEFAULT 0,
-                               milestone_closed_count INT NOT NULL DEFAULT 0,
-                               labels_count         INT NOT NULL DEFAULT 0,
-                               milestones_count     INT NOT NULL DEFAULT 0
+                               type  VARCHAR(50) PRIMARY KEY,
+                               cnt INT NOT NULL DEFAULT 0
 );
 
-MERGE INTO summary_count (id) KEY(id) VALUES (1);
+-- 2) 초기 row 삽입
+INSERT INTO summary_count(type) VALUES
+                                    ('issue_open'),
+                                    ('issue_closed'),
+                                    ('milestone_open'),
+                                    ('milestone_closed');

--- a/backend/src/test/resources/schema-test.sql
+++ b/backend/src/test/resources/schema-test.sql
@@ -4,6 +4,7 @@ CREATE TABLE `user` (
                         email VARCHAR(255) NOT NULL UNIQUE,
                         nickname VARCHAR(255) NOT NULL UNIQUE,
                         profile_image VARCHAR(255),
+                        password VARCHAR(255) NOT NULL,
                         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
🔥 작업 내용 요약
	•	회원가입 및 로그인 기능 구현
	•	JWT 인증 처리 및 인터셉터 적용
	•	비밀번호 해싱 및 예외 처리 추가
	•	로그아웃 및 관련 테스트 코드 작성
	•	코드 리팩토링 및 필터링 파라미터 개선

⸻

✅ 작업 상세 내용

✅ 회원가입 관련
	•	User 엔티티에 password 필드 추가
	•	비밀번호 해싱 처리
	•	이메일 및 닉네임 중복 시 커스텀 예외 발생
	•	기본 프로필 이미지 자동 할당 로직 추가
	•	회원가입 API 및 테스트 케이스 작성

✅ 로그인 및 인증
	•	로그인 시 JWT 생성 및 응답에 access_token 쿠키로 반환
	•	잘못된 로그인 시 401 Unauthorized 예외 처리
	•	JWT 발급 및 검증을 위한 JwtProvider 구현
	•	JWT 검증을 위한 인터셉터(AuthInterceptor) 구현 및 적용
	•	로그인 API 테스트 작성

✅ 로그아웃
	•	/logout API 구현: access_token 쿠키 제거
	•	로그아웃 API 테스트 작성

✅ 리팩토링
	•	Parser 클래스 명칭 변경
	•	이슈 필터링 파라미터 명확하게 리네이밍
	•	OpenStatus 내부의 VALUES 상수 정의