### PR TITLE
[Feat] 필터링된 이슈 갯수 조회 기능 수정

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueDao.java
@@ -8,6 +8,7 @@
     import java.util.HashMap;
     import java.util.List;
     import java.util.Map;
+    import java.util.Set;
     import java.util.stream.Collectors;
     import lombok.RequiredArgsConstructor;
     import lombok.extern.slf4j.Slf4j;
@@ -78,6 +79,34 @@
             params.put("isOpen", dto.getStatus().getState());
 
             // 작성자 필터
+            addfilteringConditionDynamic(dto, params, sql);
+
+            return sql.toString();
+        }
+
+        public Integer countIssuesByOpenStatus(boolean isOpen) {
+            String sql = "SELECT COUNT(*) FROM issue WHERE is_open = ?";
+            return jdbcTemplate.queryForObject(sql, Integer.class, isOpen);
+        }
+        public Map<String, Integer> countFilteredIssues(IssueFilterParamDto dto) {
+            StringBuilder sql = new StringBuilder("WITH filtered_issues AS (\n");
+            Map<String, Object> params = new HashMap<>();
+
+            sql.append("SELECT is_open FROM issue WHERE 1=1\n");
+
+            // 동적 필터링
+            addfilteringConditionDynamic(dto, params, sql);
+
+            sql.append(")\n");
+            sql.append("SELECT is_open, COUNT(*) as count FROM filtered_issues GROUP BY is_open");
+
+            List<Map<String, Object>> result = namedParameterJdbcTemplate.queryForList(sql.toString(), params);
+
+            return getCountMap(result);
+        }
+
+        private void addfilteringConditionDynamic(IssueFilterParamDto dto, Map<String, Object> params, StringBuilder sql) {
+            // 작성자 필터
             addAuthorCondition(dto.getAuthorId(), params, sql);
             // 담당자 필터
             addAssigneeCondition(dto.getAssigneeId(), params, sql);
@@ -87,21 +116,20 @@
             addMilestoneCondition(dto.getMilestoneId(), params, sql);
             // 라벨 필터
             addLabelConditions(dto.getLabelIds(), params, sql);
-
-            return sql.toString();
         }
 
-        private void addLabelConditions(List<Long> labelIds, Map<String, Object> params, StringBuilder sql) {
+        private void addLabelConditions(Set<Long> labelIds, Map<String, Object> params, StringBuilder sql) {
             // 라벨 필터링 - IN + GROUP BY + HAVING
             if (labelIds != null && !labelIds.isEmpty()) {
                 sql.append(" AND issue_id IN (\n");
                 sql.append("SELECT il.issue_id \nFROM issue_label il \nWHERE il.label_id IN (");
 
+                List<Long> labelList = new ArrayList<>(labelIds);
                 List<String> labelParamNames = new ArrayList<>();
                 for (int i = 0; i < labelIds.size(); i++) {
                     String paramName = "label" + i;
                     labelParamNames.add(":" + paramName);
-                    params.put(paramName, labelIds.get(i));
+                    params.put(paramName, labelList.get(i));
                 }
 
                 sql.append(String.join(", ", labelParamNames));
@@ -149,9 +177,22 @@
             }
         }
 
-        public Integer countIssuesByOpenStatus(boolean isOpen) {
-            String sql = "SELECT COUNT(*) FROM issue WHERE is_open = ?";
-            return jdbcTemplate.queryForObject(sql, Integer.class, isOpen);
+        private Map<String, Integer> getCountMap(List<Map<String, Object>> result) {
+            int open = 0, close = 0;
+            for (Map<String, Object> row : result) {
+                Boolean isOpen = (Boolean) row.get("is_open");
+                int count = ((Number) row.get("count")).intValue();
+                if (Boolean.TRUE.equals(isOpen)) {
+                    open = count;
+                } else {
+                    close = count;
+                }
+            }
+
+            Map<String, Integer> counts = new HashMap<>();
+            counts.put("open", open);
+            counts.put("close", close);
+            return counts;
         }
 
         public int updateIssueStatusByIds(boolean isOpen, List<Long> issueIds) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -71,6 +71,6 @@ public class IssueRequestDto {
         private Long commentAuthorId;
         private Long milestoneId;
         private OpenStatus status;
-        private List<Long> labelIds;
+        private Set<Long> labelIds;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueResponseDto.java
@@ -18,6 +18,8 @@ public class IssueResponseDto {
     @Builder
     public static class IssueListDto {
         private List<IssueInfo> issues;
+        private Integer openCount;
+        private Integer closeCount;
         private Integer page;
         private Integer size;
         private Integer totalPages;

--- a/backend/src/main/java/codesquad/team4/issuetracker/util/IssueFilteringParser.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/util/IssueFilteringParser.java
@@ -2,8 +2,8 @@ package codesquad.team4.issuetracker.util;
 
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class IssueFilteringParser {
     public static IssueRequestDto.IssueFilterParamDto parseFilterCondition(String query) {
@@ -14,7 +14,7 @@ public class IssueFilteringParser {
         Long assigneeId = null;
         Long milestoneId = null;
         Long commentAuthorId = null;
-        List<Long> labelIds = new ArrayList<>();
+        Set<Long> labelIds = new HashSet<>();
 
         for (String condition : conditions) {
             if (!condition.contains(":")) continue;

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -1,10 +1,11 @@
 package codesquad.team4.issuetracker.issue;
 
+import static codesquad.team4.issuetracker.util.IssueFilteringParser.parseFilterCondition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.count.dto.IssueCountDto;
+import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueFilterParamDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
@@ -12,13 +13,15 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueInfo;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.IssueListDto;
 import codesquad.team4.issuetracker.label.dto.LabelResponseDto.LabelInfo;
 import codesquad.team4.issuetracker.util.OpenStatus;
-import codesquad.team4.issuetracker.util.IssueFilteringParser;
 import codesquad.team4.issuetracker.util.TestDataHelper;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -281,7 +284,7 @@ class IssueServiceH2Test {
         Long milestoneId, Long commentAuthorId, List<Long> labelIds) {
 
         // given
-        IssueRequestDto.IssueFilterParamDto filterDto = IssueFilteringParser.parseFilterCondition(q);
+        IssueRequestDto.IssueFilterParamDto filterDto = parseFilterCondition(q);
 
         // when
         IssueResponseDto.IssueListDto result = issueService.getIssues(filterDto, 0, 10);
@@ -311,5 +314,39 @@ class IssueServiceH2Test {
                 assertThat(issueLabelIds).containsAll(labelIds);
             }
         });
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideIssueFilterDtosWithCounts")
+    @DisplayName("이슈를 필터링하는경우 필터링된 열린 이슈 갯수와 닫힌 이슈 갯수를 함께 응답한다")
+    void testFilteredIssueCounts(IssueFilterParamDto filterDto, int expectedOpen, int expectedClose) {
+        IssueResponseDto.IssueListDto result = issueService.getIssues(filterDto, 0, 10);
+
+        assertThat(result.getOpenCount()).isEqualTo(expectedOpen);
+        assertThat(result.getCloseCount()).isEqualTo(expectedClose);
+    }
+
+    private static Stream<Arguments> provideIssueFilterDtosWithCounts() {
+        return Stream.of(
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).build(), 4, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).build(), 4, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).assigneeId(2L).build(), 1, 1),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).commentAuthorId(3L).build(), 0, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).commentAuthorId(3L).build(), 0, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).commentAuthorId(2L).build(), 1, 1),
+            Arguments.of(
+                IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).labelIds(Set.of(1L)).build(), 0, 0),
+            Arguments.of(
+                IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).labelIds(Set.of(1L, 2L)).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).authorId(3L).milestoneId(1L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).labelIds(Set.of(1L, 2L, 3L)).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).authorId(3L).assigneeId(4L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).milestoneId(2L).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).labelIds(Set.of(5L)).build(), 0, 0),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.OPEN).commentAuthorId(2L).build(), 1, 1),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).build(), 4, 2),
+            Arguments.of(IssueFilterParamDto.builder().status(OpenStatus.CLOSE).labelIds(Set.of(1L)).build(), 2, 0)
+        );
     }
 }

--- a/backend/src/test/java/codesquad/team4/issuetracker/util/IssueFilteringParserTest.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/util/IssueFilteringParserTest.java
@@ -24,7 +24,7 @@ public class IssueFilteringParserTest {
         assertThat(filterDto.getAssigneeId()).isEqualTo(assigneeId);
         assertThat(filterDto.getMilestoneId()).isEqualTo(milestoneId);
         assertThat(filterDto.getCommentAuthorId()).isEqualTo(commentAuthorId);
-        assertThat(filterDto.getLabelIds()).containsExactlyElementsOf(labelIds);
+        assertThat(filterDto.getLabelIds()).containsAnyElementsOf(labelIds);
     }
 
     private static Stream<Arguments> provideFilterConditions() {


### PR DESCRIPTION
🔥 작업 내용 요약
- 필터링된 이슈 갯수 조회 기능 수정

⸻

✅ 작업 상세 내용
- 필터링 조건마다 갯수 조회 하도록 수정
- 카운트 쿼리는 별도의 쿼리로 처리
   - 한방 쿼리로 처리시 row가 없는 경우 count를 가져오지 못함
- 메인 페이지 이슈 조회 API에서 열린 갯수, 닫힌 갯수 나오도록 수정
- 레이블 필터링 조건 List -> Set으로 수정

Close #97 