### PR TITLE
[Feat] 인가 로직 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
+
     //bcrypt
     implementation 'org.mindrot:jbcrypt:0.4'
     //jwt

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,7 +30,6 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
-    implementation 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
 
     //bcrypt
     implementation 'org.mindrot:jbcrypt:0.4'

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
@@ -4,10 +4,21 @@ import codesquad.team4.issuetracker.auth.AuthInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -35,6 +46,21 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        //커넥션 풀 설정
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(50);
+        connectionManager.setDefaultMaxPerRoute(20);
+
+        //HttpClient 생성
+        HttpClient httpClent = HttpClients.custom()
+            .setConnectionManager(connectionManager)
+            .build();
+
+        //RestTemplate에 사용할 팩토리 성정
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClent);
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(5000);
+
+        return new RestTemplate(factory);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/config/WebConfig.java
@@ -4,21 +4,14 @@ import codesquad.team4.issuetracker.auth.AuthInterceptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
-import org.apache.hc.core5.util.Timeout;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
+
+
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -46,21 +39,9 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Bean
     public RestTemplate restTemplate() {
-        //커넥션 풀 설정
-        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        connectionManager.setMaxTotal(50);
-        connectionManager.setDefaultMaxPerRoute(20);
-
-        //HttpClient 생성
-        HttpClient httpClent = HttpClients.custom()
-            .setConnectionManager(connectionManager)
-            .build();
-
-        //RestTemplate에 사용할 팩토리 성정
-        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClent);
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(3000);
         factory.setReadTimeout(5000);
-
         return new RestTemplate(factory);
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/ExceptionMessage.java
@@ -20,4 +20,5 @@ public class ExceptionMessage {
     public static final String NOT_FOUND_EMAIL = "이메일을 공개로 전환해주세요.";
     public static final String INVALID_LOGINTYPE_GITHUB = "이메일로 로그인해 주세요.";
     public static final String INVALID_LOGINTYPE_LOCAL = "깃허브로 로그인해 주세요.";
+    public static final String NOT_AUTHOR = "작성자만 접근할 수 있습니다.";
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/NotAuthorException.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/exception/unauthorized/NotAuthorException.java
@@ -1,0 +1,7 @@
+package codesquad.team4.issuetracker.exception.unauthorized;
+
+import static codesquad.team4.issuetracker.exception.ExceptionMessage.NOT_AUTHOR;
+
+public class NotAuthorException extends UnauthorizedException{
+    public NotAuthorException() {super(NOT_AUTHOR);}
+}

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueController.java
@@ -9,7 +9,6 @@ import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto.ApiMessageDto;
 import codesquad.team4.issuetracker.response.ApiResponse;
 import codesquad.team4.issuetracker.util.IssueFilteringParser;
-import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -7,10 +7,13 @@ import codesquad.team4.issuetracker.count.dto.IssueCountDto;
 import codesquad.team4.issuetracker.entity.Issue;
 import codesquad.team4.issuetracker.entity.IssueAssignee;
 import codesquad.team4.issuetracker.entity.IssueLabel;
+import codesquad.team4.issuetracker.entity.User;
 import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
+import codesquad.team4.issuetracker.count.dto.IssueCountDto;
+import codesquad.team4.issuetracker.exception.unauthorized.NotAuthorException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueUpdateDto;
 import codesquad.team4.issuetracker.issue.dto.IssueResponseDto;
@@ -263,9 +266,12 @@ public class IssueService {
     }
 
     @Transactional
-    public ApiMessageDto updateIssue(Long id, IssueRequestDto.IssueUpdateDto request, String uploadUrl) {
+    public ApiMessageDto updateIssue(Long id, IssueRequestDto.IssueUpdateDto request, String uploadUrl, User user) {
         Issue oldIssue = issueRepository.findById(id)
                 .orElseThrow(() -> new IssueNotFoundException(id));
+
+        //작성자 검증
+        validateAuthor(oldIssue.getAuthorId(), user);
 
         if (request.getMilestoneId() != null) {
             milestoneRepository.findById(request.getMilestoneId())
@@ -400,12 +406,20 @@ public class IssueService {
     }
 
     @Transactional
-    public void deleteIssue(Long issueId) {
+    public void deleteIssue(Long issueId, User user) {
         Issue issue = issueRepository.findById(issueId)
                 .orElseThrow(() -> new IssueNotFoundException(issueId));
+
+        validateAuthor(issue.getAuthorId(), user);
 
         boolean wasOpen = issue.isOpen();
         issueRepository.deleteById(issueId);
         eventPublisher.publishEvent(new IssueEvent.Deleted(wasOpen));
+    }
+
+    private void validateAuthor (Long authorId, User user) {
+        if (!authorId.equals(user.getId())) {
+            throw new NotAuthorException();
+        }
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/IssueService.java
@@ -12,7 +12,6 @@ import codesquad.team4.issuetracker.exception.notfound.AssigneeNotFoundException
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.LabelNotFoundException;
 import codesquad.team4.issuetracker.exception.notfound.MilestoneNotFoundException;
-import codesquad.team4.issuetracker.count.dto.IssueCountDto;
 import codesquad.team4.issuetracker.exception.unauthorized.NotAuthorException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto.IssueUpdateDto;

--- a/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
+++ b/backend/src/test/java/codesquad/team4/issuetracker/issue/IssueServiceH2Test.java
@@ -4,6 +4,8 @@ import static codesquad.team4.issuetracker.util.IssueFilteringParser.parseFilter
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.count.dto.IssueCountDto;
 import codesquad.team4.issuetracker.exception.notfound.IssueNotFoundException;
 import codesquad.team4.issuetracker.issue.dto.IssueRequestDto;
@@ -44,6 +46,8 @@ class IssueServiceH2Test {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    private User author;
+
     @BeforeEach
     void setUp() {
         //유저 생성
@@ -81,6 +85,12 @@ class IssueServiceH2Test {
         TestDataHelper.insertComment(jdbcTemplate, 3L, "댓글3", 2L, 3L, null);
         TestDataHelper.insertComment(jdbcTemplate, 4L, "댓글4", 3L, 3L, null);
         TestDataHelper.insertComment(jdbcTemplate, 5L, "댓글5", 3L, 6L, null);
+
+        author = User.builder()
+            .id(1L)
+            .email("user1@test.com")
+            .nickname("사용자1")
+            .build();
     }
 
 
@@ -172,7 +182,7 @@ class IssueServiceH2Test {
         Long issueId = 999L;
 
         //when & then
-        assertThatThrownBy(() -> issueService.deleteIssue(issueId))
+        assertThatThrownBy(() -> issueService.deleteIssue(issueId, author))
             .isInstanceOf(IssueNotFoundException.class);
     }
 


### PR DESCRIPTION
🔥 작업 내용 요약
* 이슈 수정/삭제 시 작성자 확인 기능 구현
* 댓글 수정/삭제 시 작성자 확인 기능 구현

---
✅ 작업 상세 내용
* Controller에서 유저 정보를 파라미터로 서비스에 전달
  * AuthInterceptor에서 로그인한 사용자 정보를 HttpServletRequest의 attribute에 저장함
* IssueService / CommentService 내부에서 작성자 ID와 요청자 ID가 일치하는지 확인
  * 일치하지 않으면 NotAuthorException 예외 발생
* 테스트 코드 추가

---
📎기타
* RestTemplate에 아래와 같이 PoolingHttpClientConnectionManager를 이용해 커넥션 풀과 타임아웃을 설정하려고 했으나 버전 충돌 문제 발생.
---
Close #99