### PR TITLE
[FEAT]  이슈 수정 시 마일스톤 삭제 처리 로직 추가 및 리뷰 반영

### DIFF
--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -25,7 +25,11 @@ public class OAuthController {
 
     @GetMapping("/login")
     public ResponseEntity<OAuthResponseDto.OAuthLoginUrl> githubLogin(HttpSession session) {
-        OAuthResponseDto.OAuthLoginUrl githubUrl = oAuthService.createGithubAuthorizeUrl(session);
+        //session에 state 저장
+        String state = oAuthService.createGithubAuthorizeState();
+        session.setAttribute("oauth_state", state);
+        //Github 인증 URL 구성
+        OAuthResponseDto.OAuthLoginUrl githubUrl = oAuthService.buildGithubAuthorizeUrl(state);
         return ResponseEntity.ok(githubUrl);
     }
 

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -5,6 +5,7 @@ import codesquad.team4.issuetracker.auth.dto.AuthResponseDto;
 import codesquad.team4.issuetracker.auth.oauth.dto.OAuthRequestDto;
 import codesquad.team4.issuetracker.auth.oauth.dto.OAuthResponseDto;
 import codesquad.team4.issuetracker.entity.User;
+import codesquad.team4.issuetracker.exception.badrequest.InvalidOAuthStateException;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -45,7 +46,13 @@ public class OAuthController {
 
     //GitHub 인증 처리 + 로그인/회원가입
     private User processOAuthCallback(String code, String state, HttpSession session) {
-        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code, state), session);
+        //state 값 비교
+        String savedState = (String) session.getAttribute("oauth_state");
+        if (!state.equals(savedState)) {
+            throw new InvalidOAuthStateException();
+        }
+
+        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code, state));
     }
 
     //JWT 발급 및 쿠키 설정

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -25,10 +25,11 @@ public class OAuthController {
     private final JwtProvider jwtProvider;
 
     @GetMapping("/login")
-    public ResponseEntity<OAuthResponseDto.OAuthLoginUrl> githubLogin(HttpSession session) {
+    public ResponseEntity<OAuthResponseDto.OAuthLoginUrl> githubLogin(HttpSession session, HttpServletResponse response) {
         //session에 state 저장
         String state = oAuthService.createGithubAuthorizeState();
         session.setAttribute("oauth_state", state);
+
         //Github 인증 URL 구성
         OAuthResponseDto.OAuthLoginUrl githubUrl = oAuthService.buildGithubAuthorizeUrl(state);
         return ResponseEntity.ok(githubUrl);
@@ -52,7 +53,7 @@ public class OAuthController {
 
     //state 인증 + session 만료
     private void validateState(String state, HttpSession session) {
-        String savedState = (String) session.getAttribute("oauth_sate");
+        String savedState = (String) session.getAttribute("oauth_state");
         if (!state.equals(savedState)) {
             throw new InvalidOAuthStateException();
         }

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthController.java
@@ -46,13 +46,17 @@ public class OAuthController {
 
     //GitHub 인증 처리 + 로그인/회원가입
     private User processOAuthCallback(String code, String state, HttpSession session) {
-        //state 값 비교
-        String savedState = (String) session.getAttribute("oauth_state");
+        validateState(state, session);
+        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code));
+    }
+
+    //state 인증 + session 만료
+    private void validateState(String state, HttpSession session) {
+        String savedState = (String) session.getAttribute("oauth_sate");
         if (!state.equals(savedState)) {
             throw new InvalidOAuthStateException();
         }
-
-        return oAuthService.handleCallback(new OAuthRequestDto.GitHubCallback(code, state));
+        session.invalidate();
     }
 
     //JWT 발급 및 쿠키 설정

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
@@ -42,11 +42,7 @@ public class OAuthService {
     private static final String GITHUB_USER_EMAIL_API_URL = "https://api.github.com/user/emails";
 
 
-    public OAuthResponseDto.OAuthLoginUrl createGithubAuthorizeUrl(HttpSession session) {
-        //state 생성 및 세션에 저장
-        String state = UUID.randomUUID().toString();
-        session.setAttribute("oauth_state", state);
-
+    public OAuthResponseDto.OAuthLoginUrl buildGithubAuthorizeUrl(String state) {
         //Github 인증 URL 구성
         String githubUrl = UriComponentsBuilder.fromHttpUrl(GITHUB_AUTHORIZE_URL)
             .queryParam("client_id", clientId)
@@ -59,6 +55,11 @@ public class OAuthService {
         return OAuthResponseDto.OAuthLoginUrl.builder()
             .url(githubUrl)
             .build();
+    }
+
+    public String createGithubAuthorizeState() {
+        //state 생성
+        return UUID.randomUUID().toString();
     }
 
     public User handleCallback(OAuthRequestDto.GitHubCallback callback, HttpSession session) {

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
@@ -69,7 +69,6 @@ public class OAuthService {
         OAuthResponseDto.GitHubUserResponse userInfo = fetchGitHubUser(accessToken);
         //회원가입/로그인 처리
         Optional<User> optionalUser = userRepository.findByEmail(userInfo.getEmail());
-
         if (optionalUser.isPresent()) {
             User user = optionalUser.get();
             validateLoginType(user);

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/OAuthService.java
@@ -62,13 +62,7 @@ public class OAuthService {
         return UUID.randomUUID().toString();
     }
 
-    public User handleCallback(OAuthRequestDto.GitHubCallback callback, HttpSession session) {
-        //state 값 비교
-        String savedState = (String) session.getAttribute("oauth_state");
-        if (!callback.getState().equals(savedState)) {
-            throw new InvalidOAuthStateException();
-        }
-
+    public User handleCallback(OAuthRequestDto.GitHubCallback callback) {
         //access tocken 요청
         String accessToken = requestAccessToken(callback.getCode());
         //Github 사용자 정보 요청

--- a/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/dto/OAuthRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/auth/oauth/dto/OAuthRequestDto.java
@@ -11,6 +11,5 @@ public class OAuthRequestDto {
     @Builder
     public static class GitHubCallback {
         private String code;
-        private String state;
     }
 }

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/IssueCountListener.java
@@ -4,20 +4,19 @@ import codesquad.team4.issuetracker.count.CountDao;
 import codesquad.team4.issuetracker.issue.IssueEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.context.event.EventListener;
 
 @Component
 @RequiredArgsConstructor
 public class IssueCountListener {
     private final CountDao countDao;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onCreated(IssueEvent.Created e) {
         countDao.increment(CountDao.ISSUE_OPEN);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onStatusChanged(IssueEvent.StatusChanged e) {
         if (e.isClosing()) {
             countDao.decrement(CountDao.ISSUE_OPEN);
@@ -28,7 +27,7 @@ public class IssueCountListener {
         }
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onDeleted(IssueEvent.Deleted e) {
         if (e.isWasOpen()) {
             countDao.decrement(CountDao.ISSUE_OPEN);

--- a/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/count/Listener/MilestoneCountListener.java
@@ -5,8 +5,7 @@ import codesquad.team4.issuetracker.milestone.MilestoneEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.context.event.EventListener;
 
 @Slf4j
 @Component
@@ -14,12 +13,12 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class MilestoneCountListener {
     private final CountDao countDao;
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onCreated(MilestoneEvent.Created e) {
         countDao.increment(CountDao.MILESTONE_OPEN);
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onStatusChanged(MilestoneEvent.StatusChanged e) {
         if (e.isClosing()) {
             countDao.decrement(CountDao.MILESTONE_OPEN);
@@ -30,7 +29,7 @@ public class MilestoneCountListener {
         }
     }
 
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
     public void onDeleted(MilestoneEvent.Deleted e) {
         if (e.isWasOpen()) {
             countDao.decrement(CountDao.MILESTONE_OPEN);

--- a/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
+++ b/backend/src/main/java/codesquad/team4/issuetracker/issue/dto/IssueRequestDto.java
@@ -46,6 +46,7 @@ public class IssueRequestDto {
         private Long milestoneId;
         private Boolean isOpen;
         private Boolean removeImage;
+        private Boolean removeMilestone;
     }
 
     @AllArgsConstructor


### PR DESCRIPTION
🔥 작업 내용 요약
* session 관련 로직 Controller에 위임
* 세션 만료 로직 추가
* 이슈 수정 요청 시 "removeMilestone": true를 전달하면 기존 마일스톤을 제거할 수 있도록 마일스톤 삭제 처리 로직을 추가
* 이벤트 리스너 수정

✅ 작업 상세 내용
* GitHub OAuth 로그인 시 세션 생성 및 state 검증 로직을 Controller로 이동
* 콜백 처리 후 세션 삭제 로직 추가
* "removeMilestone": true 요청 시 마일스톤을 null로 설정하는 로직 추가 
* @TransactionalEventListener → @EventListener로 변경하여 이벤트를 트랜잭션 내부에서 즉시 처리되도록 리스너 수정

Close #101